### PR TITLE
Fix spelling mistakes

### DIFF
--- a/src/Table.js
+++ b/src/Table.js
@@ -608,7 +608,7 @@ class Table extends React.Component {
           nextRowHeight = onRerenderRowHeight(rowData) || rowHeight;
         }
 
-        let row = this.randerRowData(bodyCells, rowData, {
+        let row = this.renderRowData(bodyCells, rowData, {
           index,
           top,
           rowWidth,


### PR DESCRIPTION
fixn `randerRowData` to `renderRowData` in `Table.js`