### PR TITLE
Support `rowClassName` on Table

### DIFF
--- a/src/Table.js
+++ b/src/Table.js
@@ -77,7 +77,8 @@ type Props = {
   onTouchMove?: (event: SyntheticTouchEvent<*>) => void, // for tests
   bodyRef?: React.ElementRef<*>,
   loadAnimation?: boolean,
-  showHeader?: boolean
+  showHeader?: boolean,
+  rowClassName?: string | ((rowData: Object) => string)
 };
 
 type State = {
@@ -716,7 +717,15 @@ class Table extends React.Component<Props, State> {
   }
 
   renderRow(props: Object, cells: Array<any>, shouldRenderExpandedRow?: boolean, rowData?: Object) {
+    const { rowClassName } = this.props;
     const { shouldFixedColumn } = this.state;
+
+    if (_.isFunction(rowClassName)) {
+      props.className = rowClassName(rowData);
+    } else {
+      props.className = rowClassName;
+    }
+
     // IF there are fixed columns, add a fixed group
     if (shouldFixedColumn) {
       let fixedCells = cells.filter(cell => cell.props.fixed);

--- a/test/TableSpec.js
+++ b/test/TableSpec.js
@@ -358,4 +358,68 @@ describe('Table', () => {
     );
     assert.equal(instanceDom.querySelectorAll('.rs-table-header-row-wrapper').length, 0);
   });
+
+  it('Should hava row className', () => {
+    const instanceDom = getDOMNode(
+      <Table
+        rowClassName="custom-row"
+        minHeight={500}
+        data={[
+          {
+            id: 1,
+            name: 'a'
+          },
+          {
+            id: 2,
+            name: 'b'
+          }
+        ]}
+      >
+        <Column>
+          <HeaderCell>11</HeaderCell>
+          <Cell>12</Cell>
+        </Column>
+        <Column>
+          <HeaderCell>11</HeaderCell>
+          <Cell>12</Cell>
+        </Column>
+      </Table>
+    );
+    assert.equal(instanceDom.querySelectorAll('.rs-table-row.custom-row').length, 3);
+  });
+
+  it('Should hava row className by rowClassName()', () => {
+    const instanceDom = getDOMNode(
+      <Table
+        rowClassName={rowData => {
+          if (rowData && rowData.id === 1) {
+            return 'custom-row';
+          }
+          return 'default-row';
+        }}
+        minHeight={500}
+        data={[
+          {
+            id: 1,
+            name: 'a'
+          },
+          {
+            id: 2,
+            name: 'b'
+          }
+        ]}
+      >
+        <Column>
+          <HeaderCell>11</HeaderCell>
+          <Cell>12</Cell>
+        </Column>
+        <Column>
+          <HeaderCell>11</HeaderCell>
+          <Cell>12</Cell>
+        </Column>
+      </Table>
+    );
+    assert.equal(instanceDom.querySelectorAll('.rs-table-row.custom-row').length, 1);
+    assert.equal(instanceDom.querySelectorAll('.rs-table-row.default-row').length, 2);
+  });
 });


### PR DESCRIPTION
```js
<Table rowClassName="custom-row" />

// or
<Table rowClassName={(rowData)=>{
    if(rowData && rowData.status==='error'){
         return 'error-row'
    }
}} />
```

feature request: https://github.com/rsuite/rsuite/issues/257
