### PR TITLE
add debounce option

### DIFF
--- a/src/Table.js
+++ b/src/Table.js
@@ -276,7 +276,7 @@ class Table extends React.Component<Props, State> {
     this.calculateRowMaxHeight();
     bindElementResize(this.table, _.debounce(this.calculateTableWidth, 400, {
       'leading': true,
-      'trailing': false
+      'trailing': true
     }));
 
     const options = { passive: false };

--- a/src/Table.js
+++ b/src/Table.js
@@ -274,7 +274,10 @@ class Table extends React.Component<Props, State> {
     this.calculateTableWidth();
     this.calculateTableContextHeight();
     this.calculateRowMaxHeight();
-    bindElementResize(this.table, _.debounce(this.calculateTableWidth, 400));
+    bindElementResize(this.table, _.debounce(this.calculateTableWidth, 400, {
+      'leading': true,
+      'trailing': false
+    }));
 
     const options = { passive: false };
 


### PR DESCRIPTION
Invoke `calculateTableWidth` when clicked, debouncing subsequent calls.