### PR TITLE
Fix move scrollbar issues

### DIFF
--- a/src/Scrollbar.js
+++ b/src/Scrollbar.js
@@ -149,7 +149,7 @@ class Scrollbar extends React.PureComponent<Props, State> {
       return;
     }
 
-    if (event.buttons === 0 || _.get(window, 'event.buttons') === 0) {
+    if (_.get(event, 'buttons') === 0 || _.get(window, 'event.buttons') === 0) {
       this.releaseMouseMoves();
       return;
     }

--- a/src/Scrollbar.js
+++ b/src/Scrollbar.js
@@ -148,6 +148,12 @@ class Scrollbar extends React.PureComponent<Props, State> {
     if (!this.mouseMoveTracker || !this.mouseMoveTracker.isDragging()) {
       return;
     }
+
+    if (event.buttons === 0 || _.get(window, 'event.buttons') === 0) {
+      this.releaseMouseMoves();
+      return;
+    }
+
     this.handleScroll(vertical ? deltaY : deltaX, event);
   };
 


### PR DESCRIPTION
When the mouse clicks the left button on the scroll bar, then moves the mouse to the outside of the browser, release the left mouse button, and the event of the scroll bar is not unbound.

Fix: https://github.com/rsuite/rsuite/issues/725
