### PR TITLE
Fixed the `affixHeader` feature, which does not hide the table header…

### DIFF
--- a/docs/md/AffixTable.md
+++ b/docs/md/AffixTable.md
@@ -72,6 +72,9 @@ class AutoHeightTable extends React.Component {
             <Cell dataKey="email" />
           </Column>
         </Table>
+        <div style={{ height: 2000 }}>
+          <hr />
+        </div>
       </div>
     );
   }

--- a/src/Table.js
+++ b/src/Table.js
@@ -350,9 +350,12 @@ class Table extends React.Component<Props, State> {
   updateAffixHeaderStatus = () => {
     const { affixHeader } = this.props;
     const top = typeof affixHeader === 'number' ? affixHeader : 0;
-    const { affixHeaderOffset } = this.state;
+    const { affixHeaderOffset, contentHeight } = this.state;
     const scrollY = window.scrollY || window.pageYOffset;
-    const fixedHeader = scrollY - (affixHeaderOffset.top - top) >= 0;
+    const fixedHeader =
+      scrollY - (affixHeaderOffset.top - top) >= 0 &&
+      scrollY < affixHeaderOffset.top - top + contentHeight;
+
     if (this.affixHeaderWrapper) {
       toggleClass(this.affixHeaderWrapper, 'fixed', fixedHeader);
     }


### PR DESCRIPTION
… when the scrolling range is outside the Table body