### PR TITLE
feat(OnRowContextMenu): Add an optional onRowContextMenu property

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ const App = () => (
 | onDataUpdated            | (nextData: object[], scrollTo: (coord: { x: number; y: number }) => void) => void | Callback after table data update.                                                             |
 | onExpandChange           | (expanded:boolean,rowData:object)=>void                                           | Tree table, the callback function in the expanded node                                        |
 | onRowClick               | (rowData:object, event: SyntheticEvent)=>void                                     | Click the callback function after the row and return to `rowDate`                             |
+| onRowContextMenu         | (rowData:object, event: SyntheticEvent)=>void                                     | Invoke the callback function on contextMenu and pass the `rowData`                            |
 | onScroll                 | (scrollX:object, scrollY:object)=>void                                            | Callback function for scroll bar scrolling                                                    |
 | onSortColumn             | (dataKey:string, sortType:string)=>void                                           | Click the callback function of the sort sequence to return the value `sortColumn`, `sortType` |
 | renderEmpty              | (info: React.ReactNode) => React.ReactNode                                        | Customized data is empty display content                                                      |

--- a/src/Table.d.ts
+++ b/src/Table.d.ts
@@ -36,6 +36,7 @@ export interface TableProps extends StandardProps {
   cellBordered?: boolean;
   wordWrap?: boolean;
   onRowClick?: (rowData: object, event: React.MouseEvent) => void;
+  onRowContextMenu?: (rowData: object, event: React.MouseEvent) => void;
   onScroll?: (scrollX: number, scrollY: number) => void;
   onSortColumn?: (dataKey: string, sortType?: SortType) => void;
   onExpandChange?: (expanded: boolean, rowData: object) => void;

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -121,6 +121,7 @@ class Table extends React.Component<TableProps, TableState> {
     cellBordered: PropTypes.bool,
     wordWrap: PropTypes.bool,
     onRowClick: PropTypes.func,
+    onRowContextMenu: PropTypes.func,
     onScroll: PropTypes.func,
     onSortColumn: PropTypes.func,
     onExpandChange: PropTypes.func,
@@ -1037,6 +1038,12 @@ class Table extends React.Component<TableProps, TableState> {
     };
   };
 
+  bindRowContextMenu = (rowData: object) => {
+    return (event: React.MouseEvent) => {
+      this.props.onRowContextMenu?.(rowData, event);
+    };
+  };
+
   renderRowData(
     bodyCells: any[],
     rowData: any,
@@ -1050,7 +1057,8 @@ class Table extends React.Component<TableProps, TableState> {
     const rowProps: TableRowProps = {
       ...props,
       rowRef: this.bindTableRowsRef(props.key, rowData),
-      onClick: this.bindRowClick(rowData)
+      onClick: this.bindRowClick(rowData),
+      onContextMenu: this.bindRowContextMenu(rowData)
     };
 
     const expandedRowKeys = this.getExpandedRowKeys() || [];


### PR DESCRIPTION
Hello, thank you for writing such a great table library.

If you don't mind, I had a small addition to support optional context menus on rows.  It's a new property onRowContextMenu, and it behaves much like onRowClick.

Would very much appreciate your time in reviewing this, it would allow us to improve our UX for some of our applications.

best,
-Kirat