### PR TITLE
fix(HeaderCell): missing children prop type

### DIFF
--- a/src/HeaderCell.d.ts
+++ b/src/HeaderCell.d.ts
@@ -18,6 +18,7 @@ export interface HeaderCellProps extends CellProps {
   onSortColumn?: (dataKey?: string) => void;
   flexGrow?: number;
   fixed?: boolean | 'left' | 'right';
+  children: React.ReactNode;
 }
 
 declare const HeaderCell: React.ComponentType<HeaderCellProps>;

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -25,7 +25,8 @@ class HeaderCell extends React.PureComponent<HeaderCellProps, HeaderCelltate> {
     onColumnResizeMove: PropTypes.func,
     onSortColumn: PropTypes.func,
     flexGrow: PropTypes.number,
-    fixed: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['left', 'right'])])
+    fixed: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['left', 'right'])]),
+    children: PropTypes.node
   };
   static defaultProps = {
     classPrefix: defaultClassPrefix('table-cell-header')


### PR DESCRIPTION
In the latest version (3.14.0), the typescript compiler returns an error because the typing of the prop `children` is missing in the HeaderCell component