### PR TITLE
fix: Fix `classPrefix` cannot be rendered to child elements on `<Table>`

### DIFF
--- a/docs/md/ColumnGroupTable.md
+++ b/docs/md/ColumnGroupTable.md
@@ -9,6 +9,7 @@ const FixedColumnTable = () => {
 
   return (
     <Table
+      classPrefix="rs-table"
       bordered
       height={400}
       headerHeight={80}

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -87,7 +87,6 @@ class Cell extends React.PureComponent<CellProps> {
   static contextType = TableContext;
   static propTypes = propTypes;
   static defaultProps = {
-    classPrefix: defaultClassPrefix('table-cell'),
     headerHeight: 36,
     depth: 0,
     height: 36,
@@ -95,7 +94,11 @@ class Cell extends React.PureComponent<CellProps> {
     left: 0
   };
 
-  addPrefix = (name: string) => prefix(this.props.classPrefix)(name);
+  getClassPrefix = () =>
+    this.props.classPrefix || defaultClassPrefix('table-cell', this.context.classPrefix);
+
+  addPrefix = (name: string) => prefix(this.getClassPrefix())(name);
+
   isTreeCol() {
     const { treeCol, firstColumn } = this.props;
     const { hasCustomTreeCol, isTree } = this.context;
@@ -158,7 +161,6 @@ class Cell extends React.PureComponent<CellProps> {
       renderCell,
       removed,
       wordWrap,
-      classPrefix,
       depth,
       verticalAlign,
       expanded,
@@ -170,7 +172,7 @@ class Cell extends React.PureComponent<CellProps> {
       return null;
     }
 
-    const classes = classNames(classPrefix, className, {
+    const classes = classNames(this.getClassPrefix(), className, {
       [this.addPrefix('expanded')]: expanded && this.isTreeCol(),
       [this.addPrefix('first')]: firstColumn,
       [this.addPrefix('last')]: lastColumn

--- a/src/ColumnGroup.tsx
+++ b/src/ColumnGroup.tsx
@@ -1,7 +1,8 @@
-import * as React from 'react';
+import React, { useContext } from 'react';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import { defaultClassPrefix, prefix } from './utils/prefix';
+import TableContext from './TableContext';
 
 export interface ColumnGroupProps {
   align?: 'left' | 'center' | 'right';
@@ -34,10 +35,12 @@ const ColumnGroup = React.forwardRef((props: ColumnGroupProps, ref: React.Ref<HT
   };
 
   const contentStyles = { ...styles, verticalAlign };
-  const addPrefix = React.useCallback((name: string) => prefix(classPrefix)(name), []);
+  const { classPrefix: tableClassPrefix } = useContext(TableContext);
+  const colClassPrefix = classPrefix || defaultClassPrefix('table-column-group', tableClassPrefix);
+  const addPrefix = React.useCallback((name: string) => prefix(colClassPrefix)(name), []);
 
   return (
-    <div ref={ref} className={classNames(classPrefix, className)} {...rest}>
+    <div ref={ref} className={classNames(colClassPrefix, className)} {...rest}>
       <div className={addPrefix('header')} style={styles}>
         <div className={addPrefix('header-content')} style={contentStyles}>
           {header}
@@ -61,8 +64,7 @@ const ColumnGroup = React.forwardRef((props: ColumnGroupProps, ref: React.Ref<HT
 
 ColumnGroup.displayName = 'ColumnGroup';
 ColumnGroup.defaultProps = {
-  headerHeight: 80,
-  classPrefix: defaultClassPrefix('table-column-group')
+  headerHeight: 80
 };
 
 ColumnGroup.propTypes = {

--- a/src/ColumnResizeHandler.tsx
+++ b/src/ColumnResizeHandler.tsx
@@ -44,9 +44,6 @@ const propTypes = {
 class ColumnResizeHandler extends React.Component<ColumnResizeHandlerProps> {
   static contextType = TableContext;
   static propTypes = propTypes;
-  static defaultProps = {
-    classPrefix: defaultClassPrefix('table-column-resize-spanner')
-  };
 
   columnWidth = 0;
   cursorDelta = 0;
@@ -130,7 +127,10 @@ class ColumnResizeHandler extends React.Component<ColumnResizeHandlerProps> {
       ...style
     };
 
-    const classes = classNames(classPrefix, className);
+    const classes = classNames(
+      classPrefix || defaultClassPrefix('table-column-resize-spanner', this.context.classPrefix),
+      className
+    );
     const unhandled = getUnhandledProps(propTypes, rest);
 
     return (

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import Sort from '@rsuite/icons/Sort';
 import SortUp from '@rsuite/icons/SortUp';
 import SortDown from '@rsuite/icons/SortDown';
-
+import TableContext from './TableContext';
 import ColumnResizeHandler from './ColumnResizeHandler';
 import { isNullOrUndefined, getUnhandledProps, defaultClassPrefix, prefix } from './utils';
 import Cell, { CellProps } from './Cell';
@@ -61,10 +61,7 @@ const propTypes = {
 
 class HeaderCell extends React.PureComponent<HeaderCellProps, HeaderCelltate> {
   static propTypes = propTypes;
-  static defaultProps = {
-    classPrefix: defaultClassPrefix('table-cell-header')
-  };
-
+  static contextType = TableContext;
   static getDerivedStateFromProps(nextProps: HeaderCellProps, prevState: HeaderCelltate) {
     if (nextProps.width !== prevState.width || nextProps.flexGrow !== prevState.flexGrow) {
       return {
@@ -105,7 +102,10 @@ class HeaderCell extends React.PureComponent<HeaderCellProps, HeaderCelltate> {
     }
   };
 
-  addPrefix = (name: string) => prefix(this.props.classPrefix)(name);
+  getClassPrefix = () =>
+    this.props.classPrefix || defaultClassPrefix('table-cell-header', this.context.classPrefix);
+
+  addPrefix = (name: string) => prefix(this.getClassPrefix())(name);
 
   renderResizeSpanner() {
     const { resizable, left, onColumnResizeMove, fixed, headerHeight, minWidth } = this.props;
@@ -156,14 +156,13 @@ class HeaderCell extends React.PureComponent<HeaderCellProps, HeaderCelltate> {
       children,
       left,
       sortable,
-      classPrefix,
       sortColumn,
       sortType,
       groupHeader,
       ...rest
     } = this.props;
 
-    const classes = classNames(classPrefix, className, {
+    const classes = classNames(this.getClassPrefix(), className, {
       [this.addPrefix('sortable')]: sortable
     });
     const unhandledProps = getUnhandledProps(propTypes, rest);

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import React, { useContext } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { defaultClassPrefix, getUnhandledProps, prefix } from './utils';
+import { defaultClassPrefix, prefix, mergeRefs } from './utils';
 import TableContext from './TableContext';
 import { StandardProps } from './@types/common';
 
@@ -17,7 +17,49 @@ export interface RowProps extends StandardProps {
   style?: React.CSSProperties;
 }
 
-const propTypes = {
+const Row = React.forwardRef((props: RowProps, ref: React.Ref<HTMLDivElement>) => {
+  const {
+    className,
+    width,
+    height,
+    top,
+    style,
+    isHeaderRow,
+    headerHeight,
+    rowRef,
+    classPrefix,
+    children,
+    ...rest
+  } = props;
+
+  const addPrefix = prefix(classPrefix);
+  const classes = classNames(classPrefix, className, {
+    [addPrefix('header')]: isHeaderRow
+  });
+  const { translateDOMPositionXY } = useContext(TableContext);
+
+  const styles = {
+    minWidth: width,
+    height: isHeaderRow ? headerHeight : height,
+    ...style
+  };
+
+  translateDOMPositionXY?.(styles, 0, top);
+
+  return (
+    <div role="row" {...rest} ref={mergeRefs(rowRef, ref)} className={classes} style={styles}>
+      {children}
+    </div>
+  );
+});
+
+Row.displayName = 'Row';
+Row.defaultProps = {
+  classPrefix: defaultClassPrefix('table-row'),
+  height: 46,
+  headerHeight: 40
+};
+Row.propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
   headerHeight: PropTypes.number,
@@ -28,54 +70,5 @@ const propTypes = {
   classPrefix: PropTypes.string,
   style: PropTypes.object
 };
-class Row extends React.PureComponent<RowProps> {
-  static propTypes = propTypes;
-  static defaultProps = {
-    classPrefix: defaultClassPrefix('table-row'),
-    height: 46,
-    headerHeight: 40
-  };
-  render() {
-    const {
-      className,
-      width,
-      height,
-      top,
-      style,
-      isHeaderRow,
-      headerHeight,
-      rowRef,
-      classPrefix,
-      children,
-      ...rest
-    } = this.props;
-
-    const addPrefix = prefix(classPrefix);
-    const classes = classNames(classPrefix, className, {
-      [addPrefix('header')]: isHeaderRow
-    });
-
-    const styles = {
-      minWidth: width,
-      height: isHeaderRow ? headerHeight : height,
-      ...style
-    };
-
-    const unhandledProps = getUnhandledProps(propTypes, rest);
-
-    return (
-      <TableContext.Consumer>
-        {({ translateDOMPositionXY }) => {
-          translateDOMPositionXY?.(styles, 0, top);
-          return (
-            <div role="row" {...unhandledProps} ref={rowRef} className={classes} style={styles}>
-              {children}
-            </div>
-          );
-        }}
-      </TableContext.Consumer>
-    );
-  }
-}
 
 export default Row;

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -1172,12 +1172,13 @@ class Table extends React.Component<TableProps, TableState> {
     props: TableRowProps,
     shouldRenderExpandedRow?: boolean
   ) {
-    const { renderTreeToggle, rowKey, wordWrap, isTree } = this.props;
+    const { renderTreeToggle, rowKey, wordWrap, isTree, classPrefix } = this.props;
     const hasChildren = isTree && rowData.children && Array.isArray(rowData.children);
     const nextRowKey = typeof rowData[rowKey] !== 'undefined' ? rowData[rowKey] : props.key;
 
     const rowProps: TableRowProps = {
       ...props,
+      classPrefix: `${classPrefix}-row`,
       key: nextRowKey,
       'aria-rowindex': (props.key as number) + 2,
       rowRef: this.bindTableRowsRef(props.key, rowData),
@@ -1211,9 +1212,11 @@ class Table extends React.Component<TableProps, TableState> {
   }
 
   renderRow(props: TableRowProps, cells: any[], shouldRenderExpandedRow?: boolean, rowData?: any) {
-    const { rowClassName } = this.props;
+    const { rowClassName, classPrefix } = this.props;
     const { shouldFixedColumn, width, contentWidth } = this.state;
     const { depth, ...restRowProps } = props;
+    const cellGroupClassPrefix = `${classPrefix}-cell-group`;
+
     if (typeof rowClassName === 'function') {
       restRowProps.className = rowClassName(rowData);
     } else {
@@ -1263,6 +1266,7 @@ class Table extends React.Component<TableProps, TableState> {
         <Row {...restRowProps} data-depth={depth} style={rowStyles}>
           {fixedLeftCellGroupWidth ? (
             <CellGroup
+              classPrefix={cellGroupClassPrefix}
               fixed="left"
               height={props.isHeaderRow ? props.headerHeight : props.height}
               width={fixedLeftCellGroupWidth}
@@ -1272,10 +1276,11 @@ class Table extends React.Component<TableProps, TableState> {
             </CellGroup>
           ) : null}
 
-          <CellGroup>{mergeCells(scrollCells)}</CellGroup>
+          <CellGroup classPrefix={cellGroupClassPrefix}>{mergeCells(scrollCells)}</CellGroup>
 
           {fixedRightCellGroupWidth ? (
             <CellGroup
+              classPrefix={cellGroupClassPrefix}
               fixed="right"
               style={
                 this.isRTL()
@@ -1296,7 +1301,7 @@ class Table extends React.Component<TableProps, TableState> {
 
     return (
       <Row {...restRowProps} data-depth={depth} style={rowStyles}>
-        <CellGroup>{mergeCells(cells)}</CellGroup>
+        <CellGroup classPrefix={cellGroupClassPrefix}>{mergeCells(cells)}</CellGroup>
         {shouldRenderExpandedRow && this.renderRowExpanded(rowData)}
       </Row>
     );
@@ -1329,11 +1334,12 @@ class Table extends React.Component<TableProps, TableState> {
   }
 
   renderTableHeader(headerCells: any[], rowWidth: number) {
-    const { affixHeader } = this.props;
+    const { affixHeader, classPrefix } = this.props;
     const { width: tableWidth } = this.state;
     const top = typeof affixHeader === 'number' ? affixHeader : 0;
     const headerHeight = this.getTableHeaderHeight();
     const rowProps: TableRowProps = {
+      classPrefix: `${classPrefix}-row`,
       'aria-rowindex': 1,
       rowRef: this.tableHeaderRef,
       width: rowWidth,
@@ -1541,7 +1547,7 @@ class Table extends React.Component<TableProps, TableState> {
   }
 
   renderScrollbar() {
-    const { disabledScroll, affixHorizontalScrollbar, id } = this.props;
+    const { disabledScroll, affixHorizontalScrollbar, id, classPrefix } = this.props;
     const { contentWidth, contentHeight, width, fixedHorizontalScrollbar } = this.state;
     const bottom = typeof affixHorizontalScrollbar === 'number' ? affixHorizontalScrollbar : 0;
 
@@ -1552,27 +1558,29 @@ class Table extends React.Component<TableProps, TableState> {
       return null;
     }
 
-    return (
-      <div>
-        <Scrollbar
-          tableId={id}
-          className={classNames({ fixed: fixedHorizontalScrollbar })}
-          style={{ width, bottom: fixedHorizontalScrollbar ? bottom : undefined }}
-          length={this.state.width}
-          onScroll={this.handleScrollX}
-          scrollLength={contentWidth}
-          ref={this.scrollbarXRef}
-        />
-        <Scrollbar
-          vertical
-          tableId={id}
-          length={height - headerHeight}
-          scrollLength={contentHeight}
-          onScroll={this.handleScrollY}
-          ref={this.scrollbarYRef}
-        />
-      </div>
-    );
+    return [
+      <Scrollbar
+        key="scrollbar"
+        tableId={id}
+        classPrefix={`${classPrefix}-scrollbar`}
+        className={classNames({ fixed: fixedHorizontalScrollbar })}
+        style={{ width, bottom: fixedHorizontalScrollbar ? bottom : undefined }}
+        length={this.state.width}
+        onScroll={this.handleScrollX}
+        scrollLength={contentWidth}
+        ref={this.scrollbarXRef}
+      />,
+      <Scrollbar
+        key="vertical-scrollbar"
+        classPrefix={`${classPrefix}-scrollbar`}
+        vertical
+        tableId={id}
+        length={height - headerHeight}
+        scrollLength={contentHeight}
+        onScroll={this.handleScrollY}
+        ref={this.scrollbarYRef}
+      />
+    ];
   }
 
   /**
@@ -1600,6 +1608,7 @@ class Table extends React.Component<TableProps, TableState> {
   render() {
     const {
       children,
+      classPrefix,
       className,
       data,
       width = 0,
@@ -1609,7 +1618,7 @@ class Table extends React.Component<TableProps, TableState> {
       bordered,
       cellBordered,
       wordWrap,
-      classPrefix,
+
       loading,
       showHeader,
       ...rest
@@ -1639,6 +1648,7 @@ class Table extends React.Component<TableProps, TableState> {
     return (
       <TableContext.Provider
         value={{
+          classPrefix,
           translateDOMPositionXY: this.translateDOMPositionXY,
           rtl: this.isRTL(),
           isTree,

--- a/src/TableContext.tsx
+++ b/src/TableContext.tsx
@@ -7,6 +7,7 @@ export interface TableContextProps {
   hasCustomTreeCol: boolean;
   isTree: boolean;
   translateDOMPositionXY: (style: React.CSSProperties, x: number, y: number) => void;
+  classPrefix?: string;
 }
 
 const TableContext = createContext<TableContextProps>({

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -13,4 +13,5 @@ export { default as findAllParents } from './findAllParents';
 export { default as shouldShowRowByExpanded } from './shouldShowRowByExpanded';
 export { default as resetLeftForCells } from './resetLeftForCells';
 export { default as isNumberOrTrue } from './isNumberOrTrue';
+export { default as mergeRefs } from './mergeRefs';
 export * from './requestAnimationTimeout';

--- a/src/utils/mergeRefs.ts
+++ b/src/utils/mergeRefs.ts
@@ -1,0 +1,18 @@
+type CallbackRef<T> = (ref: T | null) => void;
+type Ref<T> = React.MutableRefObject<T> | CallbackRef<T>;
+
+const toFnRef = <T>(ref?: Ref<T> | null) =>
+  !ref || typeof ref === 'function'
+    ? ref
+    : (value: T) => {
+        ref.current = value;
+      };
+
+export default function mergeRefs<T>(refA?: Ref<T> | null, refB?: Ref<T> | null) {
+  const a = toFnRef(refA);
+  const b = toFnRef(refB);
+  return (value: T | null) => {
+    if (typeof a === 'function') a(value);
+    if (typeof b === 'function') b(value);
+  };
+}

--- a/src/utils/prefix.ts
+++ b/src/utils/prefix.ts
@@ -6,9 +6,18 @@ export const getClassNamePrefix = () => {
   if (typeof __RSUITE_CLASSNAME_PREFIX__ !== 'undefined') {
     return __RSUITE_CLASSNAME_PREFIX__;
   }
+
   return globalKey;
 };
-export const defaultClassPrefix = name => `${getClassNamePrefix()}${name}`;
+export const defaultClassPrefix = (name: string, tableClassPrefix?: string) => {
+  // 当设置了 table 的 classPrefix，则使用它作为前缀，并删除 name 中的 table
+  if (tableClassPrefix) {
+    return `${tableClassPrefix}-${name?.replace('table-', '')}`;
+  }
+
+  return `${getClassNamePrefix()}${name}`;
+};
+
 export const prefix = curry((pre: string, className: string | string[]) => {
   if (!pre || !className) {
     return '';

--- a/test/TableSpec.js
+++ b/test/TableSpec.js
@@ -746,4 +746,41 @@ describe('Table', () => {
       4
     );
   });
+
+  it('Should replace all classPrefix', () => {
+    ReactTestUtils.act(() => {
+      ReactDOM.render(
+        <div id="my-list">
+          <Table
+            style={{ width: 300 }}
+            classPrefix={'my-list'}
+            data={[
+              {
+                id: 1,
+                name: 'a'
+              }
+            ]}
+          >
+            <Column width={200} fixed>
+              <HeaderCell>11</HeaderCell>
+              <Cell>12</Cell>
+            </Column>
+            <Column width={200}>
+              <HeaderCell>11</HeaderCell>
+              <Cell>12</Cell>
+            </Column>
+          </Table>
+        </div>,
+        container
+      );
+    });
+
+    const table = document.getElementById('my-list');
+
+    assert.include(table.childNodes[0].className, 'my-list');
+    assert.equal(table.querySelectorAll('.my-list-cell-group').length, 4);
+    assert.equal(table.querySelectorAll('.my-list-cell').length, 4);
+    assert.equal(table.querySelectorAll('.my-list-cell-header').length, 2);
+    assert.equal(table.querySelectorAll('.my-list-row').length, 2);
+  });
 });


### PR DESCRIPTION
fix https://github.com/rsuite/rsuite/issues/1584
fix https://github.com/rsuite/rsuite-table/issues/205