### PR TITLE
build(deps): bump element-resieze-event from 3.0.2 to 3.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8275,9 +8275,9 @@
       "dev": true
     },
     "element-resize-event": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/element-resize-event/-/element-resize-event-3.0.3.tgz",
-      "integrity": "sha512-vhGNxT87PdZA6Ak4E0QhArwGzNcSPUwSN7n9wCFLeBlY2NNuuiwguQuQIp7P5oB65PLJ892yKcHiqz1xLWeiug=="
+      "version": "3.0.6",
+      "resolved": "https://npm.hypers.cc/element-resize-event/-/element-resize-event-3.0.6.tgz",
+      "integrity": "sha512-sSeXY9rNDp86bJODW68pxLcy3A5FrPZfIgOrJHzqgYzX513Zq6/ytdBigp7KeJEpZZopBBSiO1cVuiRkZpNxLw=="
     },
     "elliptic": {
       "version": "6.5.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@rsuite/icons": "^1.0.0",
     "classnames": "^2.2.5",
     "dom-lib": "^2.0.3",
-    "element-resize-event": "^3.0.2",
+    "element-resize-event": "^3.0.6",
     "lodash": "^4.17.20"
   },
   "peerDependencies": {


### PR DESCRIPTION
fix: #226 