### PR TITLE
fix(table): fix that `flexGrow` and `wordWrap` cannot be used together

### DIFF
--- a/docs/md/WordWrapTable.md
+++ b/docs/md/WordWrapTable.md
@@ -36,7 +36,7 @@ const App = () => {
           <Cell dataKey="id" />
         </Column>
 
-        <Column width={130} fixed>
+        <Column width={130} fixed flexGrow={1}>
           <HeaderCell>First Name</HeaderCell>
           <Cell dataKey="firstName" />
         </Column>
@@ -65,7 +65,6 @@ const App = () => {
           <HeaderCell>Email</HeaderCell>
           <Cell dataKey="email" />
         </Column>
-
       </Table>
     </div>
   );

--- a/src/utils/useTableDimension.ts
+++ b/src/utils/useTableDimension.ts
@@ -158,14 +158,16 @@ const useTableDimension = (props: TableDimensionProps) => {
   }, [onTableWidthChange, setOffsetByAffix, tableRef]);
 
   useMount(() => {
-    calculateTableWidth();
     calculateTableContextHeight();
     calculateTableContentWidth();
+    calculateTableWidth();
     setOffsetByAffix();
+
     bindElementResize(tableRef.current, debounce(calculateTableWidth, 400));
   });
 
   useUpdateLayoutEffect(() => {
+    calculateTableWidth();
     calculateTableContextHeight();
     calculateTableContentWidth();
   }, [


### PR DESCRIPTION
precondition https://github.com/rsuite/rsuite-table/pull/246

fix https://github.com/rsuite/rsuite/issues/823
fix https://github.com/rsuite/rsuite/issues/1682