### PR TITLE
Add prop-types to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,8 @@
   },
   "peerDependencies": {
     "react": "^0.14.9 || >=15.3.0",
-    "react-dom": "^0.14.9 || >=15.3.0"
+    "react-dom": "^0.14.9 || >=15.3.0",
+    "prop-types": "^15.7.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",


### PR DESCRIPTION
prop-types [is required](https://github.com/rsuite/rsuite-table/search?q=prop-types) but missing from both `dependencies` and `peerDependencies`.

A package using typescript won't be using prop-types and thus the following error will be triggered:

> Error: Cannot find module 'prop-types'
