### PR TITLE
fix(x-scrollbar): fix x-scrollbar not rerender during resize

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -337,11 +337,15 @@ const Table = React.forwardRef((props: TableProps, ref) => {
       }
     },
     onTableContentWidthChange: () => {
+      forceUpdate();
+
       if (shouldUpdateScroll) {
         handleScrollLeft(0);
       }
     },
     onTableWidthChange: () => {
+      forceUpdate();
+
       if (shouldUpdateScroll) {
         handleScrollLeft(0);
       }


### PR DESCRIPTION
window resize 时，未触发 table 重渲染, 导致横向滚动条宽度错误

https://rsuitejs.com/components/table/#table-methods
官网案例中即可复现该问题