### PR TITLE
feat(Table): added support function type for shouldUpdateScroll

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,45 +94,45 @@ const App = () => (
 
 ### `<Table>`
 
-| Property                 | Type `(Default)`                                                   | Description                                                                                   |
-| ------------------------ | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
-| affixHeader              | boolean,number                                                     | Affix the table header to the specified position on the page                                  |
-| affixHorizontalScrollbar | boolean,number                                                     | Affix the table horizontal scrollbar to the specified position on the page                    |
-| autoHeight               | boolean                                                            | Automatic height                                                                              |
-| bordered                 | boolean                                                            | Show border                                                                                   |
-| cellBordered             | boolean                                                            | Show cell border                                                                              |
-| data \*                  | object[]                                                           | Table data                                                                                    |
-| defaultExpandAllRows     | boolean                                                            | Expand all nodes By default                                                                   |
-| defaultExpandedRowKeys   | string[]                                                           | Specify the default expanded row by `rowkey`                                                  |
-| defaultSortType          | enum: 'desc', 'asc'                                                | Sort type                                                                                     |
-| expandedRowKeys          | string[]                                                           | Specify the default expanded row by `rowkey` (Controlled)                                     |
-| headerHeight             | number`(40)`                                                       | Table Header Height                                                                           |
-| height                   | number`(200)`                                                      | Table height                                                                                  |
-| hover                    | boolean `(true)`                                                   | The row of the table has a mouseover effect                                                   |
-| isTree                   | boolean                                                            | Show as Tree table                                                                            |
-| loading                  | boolean                                                            | Show loading                                                                                  |
-| locale                   | object: { emptyMessage: `('No data')`, loading: `('Loading...')` } | Messages for empty data and loading states                                                    |
-| minHeight                | number `(0)`                                                       | Minimum height                                                                                |
-| onExpandChange           | (expanded:boolean,rowData:object)=>void                            | Tree table, the callback function in the expanded node                                        |
-| onRowClick               | (rowData:object, event: SyntheticEvent)=>void                      | Click the callback function after the row and return to `rowDate`                             |
-| onRowContextMenu         | (rowData:object, event: SyntheticEvent)=>void                      | Invoke the callback function on contextMenu and pass the `rowData`                            |
-| onScroll                 | (scrollX:object, scrollY:object)=>void                             | Callback function for scroll bar scrolling                                                    |
-| onSortColumn             | (dataKey:string, sortType:string)=>void                            | Click the callback function of the sort sequence to return the value `sortColumn`, `sortType` |
-| renderEmpty              | (info: React.ReactNode) => React.ReactNode                         | Customized data is empty display content                                                      |
-| renderLoading            | (loading: React.ReactNode) => React.ReactNode                      | Customize the display content in the data load                                                |
-| renderRowExpanded        | (rowDate?: Object) => React.ReactNode                              | Customize what you can do to expand a zone                                                    |
-| renderTreeToggle         | (icon:node,rowData:object,expanded:boolean)=> node                 | Tree table, the callback function in the expanded node                                        |
-| rowClassName             | string , (rowData:object)=>string                                  | Add an optional extra class name to row                                                       |
-| rowExpandedHeight        | number `(100)`                                                     | Set the height of an expandable area                                                          |
-| rowHeight                | number`(46)`, (rowData: object) => number                          | Row height                                                                                    |
-| rowKey                   | string `('key')`                                                   | Each row corresponds to the unique `key` in `data`                                            |
-| rtl                      | boolean                                                            | Right to left                                                                                 |
-| shouldUpdateScroll       | boolean`(true)`                                                    | Whether to update the scroll bar after data update                                            |
-| showHeader               | boolean `(true)`                                                   | Display header                                                                                |
-| sortColumn               | string                                                             | Sort column name ˝                                                                            |
-| sortType                 | enum: 'desc', 'asc'                                                | Sort type (Controlled)                                                                        |
-| virtualized              | boolean                                                            | Effectively render large tabular data                                                         |
-| width                    | number                                                             | Table width                                                                                   |
+| Property                 | Type `(Default)`                                                   | Description                                                                                                             |
+| ------------------------ | ------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------- |
+| affixHeader              | boolean,number                                                     | Affix the table header to the specified position on the page                                                            |
+| affixHorizontalScrollbar | boolean,number                                                     | Affix the table horizontal scrollbar to the specified position on the page                                              |
+| autoHeight               | boolean                                                            | Automatic height                                                                                                        |
+| bordered                 | boolean                                                            | Show border                                                                                                             |
+| cellBordered             | boolean                                                            | Show cell border                                                                                                        |
+| data \*                  | object[]                                                           | Table data                                                                                                              |
+| defaultExpandAllRows     | boolean                                                            | Expand all nodes By default                                                                                             |
+| defaultExpandedRowKeys   | string[]                                                           | Specify the default expanded row by `rowkey`                                                                            |
+| defaultSortType          | enum: 'desc', 'asc'                                                | Sort type                                                                                                               |
+| expandedRowKeys          | string[]                                                           | Specify the default expanded row by `rowkey` (Controlled)                                                               |
+| headerHeight             | number`(40)`                                                       | Table Header Height                                                                                                     |
+| height                   | number`(200)`                                                      | Table height                                                                                                            |
+| hover                    | boolean `(true)`                                                   | The row of the table has a mouseover effect                                                                             |
+| isTree                   | boolean                                                            | Show as Tree table                                                                                                      |
+| loading                  | boolean                                                            | Show loading                                                                                                            |
+| locale                   | object: { emptyMessage: `('No data')`, loading: `('Loading...')` } | Messages for empty data and loading states                                                                              |
+| minHeight                | number `(0)`                                                       | Minimum height                                                                                                          |
+| onExpandChange           | (expanded:boolean,rowData:object)=>void                            | Tree table, the callback function in the expanded node                                                                  |
+| onRowClick               | (rowData:object, event: SyntheticEvent)=>void                      | Click the callback function after the row and return to `rowDate`                                                       |
+| onRowContextMenu         | (rowData:object, event: SyntheticEvent)=>void                      | Invoke the callback function on contextMenu and pass the `rowData`                                                      |
+| onScroll                 | (scrollX:object, scrollY:object)=>void                             | Callback function for scroll bar scrolling                                                                              |
+| onSortColumn             | (dataKey:string, sortType:string)=>void                            | Click the callback function of the sort sequence to return the value `sortColumn`, `sortType`                           |
+| renderEmpty              | (info: React.ReactNode) => React.ReactNode                         | Customized data is empty display content                                                                                |
+| renderLoading            | (loading: React.ReactNode) => React.ReactNode                      | Customize the display content in the data load                                                                          |
+| renderRowExpanded        | (rowDate?: Object) => React.ReactNode                              | Customize what you can do to expand a zone                                                                              |
+| renderTreeToggle         | (icon:node,rowData:object,expanded:boolean)=> node                 | Tree table, the callback function in the expanded node                                                                  |
+| rowClassName             | string , (rowData:object)=>string                                  | Add an optional extra class name to row                                                                                 |
+| rowExpandedHeight        | number `(100)`                                                     | Set the height of an expandable area                                                                                    |
+| rowHeight                | number`(46)`, (rowData: object) => number                          | Row height                                                                                                              |
+| rowKey                   | string `('key')`                                                   | Each row corresponds to the unique `key` in `data`                                                                      |
+| rtl                      | boolean                                                            | Right to left                                                                                                           |
+| shouldUpdateScroll       | boolean,(event)=>({x,y}) `(true)`                                  | Use the return value of `shouldUpdateScroll` to determine whether to update the scroll after the table size is updated. |
+| showHeader               | boolean `(true)`                                                   | Display header                                                                                                          |
+| sortColumn               | string                                                             | Sort column name ˝                                                                                                      |
+| sortType                 | enum: 'desc', 'asc'                                                | Sort type (Controlled)                                                                                                  |
+| virtualized              | boolean                                                            | Effectively render large tabular data                                                                                   |
+| width                    | number                                                             | Table width                                                                                                             |
 
 ### `<Column>`
 

--- a/docs/md/TreeTable.md
+++ b/docs/md/TreeTable.md
@@ -22,7 +22,7 @@ const App = () => {
         virtualized
         minHeight={260}
         height={400}
-        rowKey="id"
+        rowKey="key"
         data={fakeTreeData}
         shouldUpdateScroll={false}
         defaultExpandedRowKeys={[0]}

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -322,9 +322,9 @@ const Table = React.forwardRef((props: TableProps, ref) => {
     vertical: boolean
   ) => {
     if (typeof shouldUpdateScroll === 'function') {
-      handleScrollTo(shouldUpdateScroll(event));
+      onScrollTo(shouldUpdateScroll(event));
     } else if (shouldUpdateScroll) {
-      vertical ? handleScrollTop(0) : handleScrollLeft(0);
+      vertical ? onScrollTop(0) : onScrollLeft(0);
     }
   };
 

--- a/src/utils/useScrollListener.ts
+++ b/src/utils/useScrollListener.ts
@@ -402,7 +402,7 @@ const useScrollListener = (props: ScrollListenerProps) => {
     forceUpdatePosition();
   };
 
-  const onScrollTo = (coord: { x: number; y: number }) => {
+  const onScrollTo = (coord: { x?: number; y?: number }) => {
     const { x, y } = coord || {};
     if (typeof x === 'number') {
       onScrollLeft(x);

--- a/src/utils/useScrollListener.ts
+++ b/src/utils/useScrollListener.ts
@@ -316,7 +316,7 @@ const useScrollListener = (props: ScrollListenerProps) => {
     forceUpdatePosition();
   };
 
-  const handleScrollTo = (coord: { x: number; y: number }) => {
+  const handleScrollTo = (coord: { x?: number; y?: number }) => {
     const { x, y } = coord || {};
     if (typeof x === 'number') {
       handleScrollLeft(x);

--- a/src/utils/useTableDimension.ts
+++ b/src/utils/useTableDimension.ts
@@ -171,7 +171,7 @@ const useTableDimension = (props: TableDimensionProps) => {
       tableWidth.current = nextWidth;
     }
 
-    if (prevWidth !== tableWidth.current) {
+    if (prevWidth && prevWidth !== tableWidth.current) {
       scrollX.current = 0;
       onTableWidthChange?.(prevWidth);
     }

--- a/test/TableSpec.js
+++ b/test/TableSpec.js
@@ -983,4 +983,44 @@ describe('Table', () => {
     });
     assert.isTrue(onScrollSpy.called);
   });
+
+  it('Should update the scroll after the size changes', () => {
+    const onScrollSpy = sinon.spy();
+    const App = React.forwardRef((props, ref) => {
+      const data = [
+        {
+          id: 1,
+          name: 'a'
+        }
+      ];
+
+      const [width, setWidth] = React.useState(100);
+      React.useImperativeHandle(ref, () => ({
+        updateWidth: () => {
+          setWidth(50);
+        }
+      }));
+
+      return (
+        <Table shouldUpdateScroll={onScrollSpy} data={data} height={10} style={{ width }}>
+          <Column>
+            <HeaderCell>id</HeaderCell>
+            <Cell dataKey="id" />
+          </Column>
+          <Column>
+            <HeaderCell>name</HeaderCell>
+            <Cell dataKey="name" />
+          </Column>
+        </Table>
+      );
+    });
+
+    const instance = getInstance(<App />);
+    expect(onScrollSpy.callCount).to.equal(1);
+    expect(onScrollSpy.firstCall.firstArg).to.equal('bodyHeightChanged');
+
+    instance.updateWidth();
+    expect(onScrollSpy.callCount).to.equal(2);
+    expect(onScrollSpy.secondCall.firstArg).to.equal('widthChanged');
+  });
 });


### PR DESCRIPTION
```ts
/**
 * Use the return value of `shouldUpdateScroll` to determine
 * whether to update the scroll after the table size is updated.
 */
  shouldUpdateScroll?:
   | boolean
   | ((event: 'bodyHeightChanged' | 'bodyWidthChanged' | 'widthChanged') => {
       x?: number;
       y?: number;
     });

```