### PR TITLE
Table Cell nested data keys and functions over data

### DIFF
--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -81,6 +81,7 @@ const Cell = React.forwardRef((props: InnerCellProps, ref: React.Ref<HTMLDivElem
     children,
     rowData,
     dataKey,
+    dataFunc,
     rowIndex,
     removed,
     rowKey,
@@ -146,7 +147,13 @@ const Cell = React.forwardRef((props: InnerCellProps, ref: React.Ref<HTMLDivElem
     contentStyles.verticalAlign = verticalAlign;
   }
 
-  let cellContent = isNil(children) && rowData ? get(rowData, dataKey) : children;
+  //let cellContent = isNil(children) && rowData ? get(rowData, dataKey) : children;
+  if(props.dataFunc){
+    var cellContent = isNil(children) && rowData ? props.dataFunc(dataKey.split(",").reduce((t,k,i,a)=>t[k],rowData))  : children;
+  }else{
+    var cellContent = isNil(children) && rowData ? dataKey.split(",").reduce((t,k,i,a)=>t[k],rowData) : children;
+  }
+
 
   if (typeof children === 'function') {
     cellContent = children(rowData, rowIndex);


### PR DESCRIPTION
Added functionality that permits nested dataKeys for a cell, and a dataFunc prop that makes it possible to run a function over the cell's data.

For example:    <Cell dataKey="customers" dataFunc={(customers)=>customers.map(e=>e.name + " " + e.surname).join(", ")}/>
will return John Doe, Topalidis Dimitrios if the row data are:

{
...
  customers:[
    {
      name:"John"
      surname:"Doe"
    },
  {
      name:"Dimitrios"
      surname:"Topalidis"
    }
  ]
}

We can also do this:  < Cell dataKey="inspection,inspectionNumber" />

if our row data are:

{
    inspection:{
        inspectionNumber:"1000"
    }

}