### PR TITLE
fix(Columns): fix Fragment render in nested array

### DIFF
--- a/src/utils/getTableColumns.ts
+++ b/src/utils/getTableColumns.ts
@@ -57,6 +57,9 @@ function getTableColumns(children) {
     } else if (ReactIs.isFragment(column)) {
       // If the column is a fragment, we need to get the columns from the children.
       return getTableColumns(column.props?.children);
+    } else if (Array.isArray(column)) {
+      // If the column is an array, need check item in the array.
+      return getTableColumns(column);
     }
 
     // If the column is not a group, we just return the column.

--- a/test/TableSpec.js
+++ b/test/TableSpec.js
@@ -1278,7 +1278,20 @@ describe('Table', () => {
             <Cell dataKey="companyName" />
           </Column>
         </React.Fragment>
-
+        {[
+          <Column key="array-0" width={200} verticalAlign="middle" sortable>
+            <HeaderCell>Company Name</HeaderCell>
+            <Cell dataKey="companyName" />
+          </Column>,
+          [
+            <React.Fragment key="array-0">
+              <Column width={200} verticalAlign="middle" sortable>
+                <HeaderCell>Company Name</HeaderCell>
+                <Cell dataKey="companyName" />
+              </Column>
+            </React.Fragment>
+          ]
+        ]}
         <Column width={200} verticalAlign="middle" sortable>
           <HeaderCell>Company Name</HeaderCell>
           <Cell dataKey="companyName" />
@@ -1288,7 +1301,7 @@ describe('Table', () => {
 
     const body = instance.querySelector('.rs-table-body-row-wrapper');
 
-    assert.equal(body.querySelectorAll('.rs-table-cell-content').length, 7);
+    assert.equal(body.querySelectorAll('.rs-table-cell-content').length, 9);
   });
 
   it('Should be aligned in ColumnGroup', () => {


### PR DESCRIPTION
## 问题
嵌套数组中的 `Fragment` 未渲染
```jsx
<Table>
  <Column>{...}</Column>,
  {[
    <Column>{...}</Column>,
    [
      <>
        <Column>{...}</Column>
      </>
    ]
  ]}
</Table>
```
第三列未展示

## 变更
递归处理 `children` 中的数组

