### PR TITLE
Fix/334

### DIFF
--- a/src/Scrollbar.tsx
+++ b/src/Scrollbar.tsx
@@ -61,7 +61,9 @@ const Scrollbar = React.forwardRef((props: ScrollbarProps, ref) => {
       horizontal: !vertical,
       hide: scrollLength <= length,
       pressed: handlePressed
-    })
+    }),
+    // keep the 'fixed' class name if it has already been given by useAffix hook
+    barRef.current?.classList.contains('fixed') && 'fixed'
   );
 
   const width = (length / scrollLength) * 100;

--- a/src/utils/useAffix.ts
+++ b/src/utils/useAffix.ts
@@ -97,8 +97,7 @@ const useAffix = (props: AffixProps) => {
     return () => {
       scrollListener.current?.off();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [affixHeader, affixHorizontalScrollbar, handleWindowScroll]);
 };
 
 export default useAffix;


### PR DESCRIPTION
# General
This MR fixes some behaviors of `affixHorizontalScrollbar` prop.
Original issue is: https://github.com/rsuite/rsuite-table/issues/334

# What this MR updates
## 1. Fix `affixHorizontalScrollbar` to be shown when `Table` component was initially rendered with empty data
Made useAffix to attach scroll event handler to `window` object whenever related dependencies are updated.
This way, the scroll event handler will be ensured to refer to latest props given to `Table` component which would be used for scroll position calculation.

## 2. Fix `affixHorizontalScrollbar` to stay when user drags it.
Modified `Scrollbar` component's dom class name composition logic to keep `fixed` class if it has already been given by `useAffix` hook.
This fix is done in a really nasty way, but I couldn't come up with other fix other than making more vast changes.
If there is better approaches, I would be happy to make change or retreat this commit for new one.
