### PR TITLE
rowHeight using is fixed in useTableDimension

### DIFF
--- a/src/utils/useTableDimension.ts
+++ b/src/utils/useTableDimension.ts
@@ -83,7 +83,7 @@ const useTableDimension = (props: TableDimensionProps) => {
     const rows = table?.querySelectorAll(`.${prefix?.('row')}`) || [];
 
     const nextContentHeight = rows.length
-      ? (Array.from(rows).map((row: Element, index: number) => getHeight(row) || getRowHeight(data?[index])) as number[]).reduce(
+      ? (Array.from(rows).map((row: Element, index: number) => getHeight(row) || getRowHeight(data?.[index])) as number[]).reduce(
           (x: number, y: number) => x + y
         )
       : 0;

--- a/src/utils/useTableDimension.ts
+++ b/src/utils/useTableDimension.ts
@@ -73,13 +73,17 @@ const useTableDimension = (props: TableDimensionProps) => {
   const headerOffset = useRef<ElementOffset | null>(null);
   const tableOffset = useRef<ElementOffset | null>(null);
 
+  const getRowHeight = (rowData = {}) => {
+    return typeof rowHeight === 'function' ? rowHeight(rowData) : rowHeight;
+  };
+
   const calculateTableContextHeight = useCallback(() => {
     const prevContentHeight = contentHeight.current;
     const table = tableRef?.current;
     const rows = table?.querySelectorAll(`.${prefix?.('row')}`) || [];
 
     const nextContentHeight = rows.length
-      ? (Array.from(rows).map((row: Element) => getHeight(row) || rowHeight) as number[]).reduce(
+      ? (Array.from(rows).map((row: Element, index: number) => getHeight(row) || getRowHeight(data?[index])) as number[]).reduce(
           (x: number, y: number) => x + y
         )
       : 0;


### PR DESCRIPTION
It is allowed in interface to pass rowHeight as function, but really it will not work correctly.
Error is reproduced when Table is hidden. Function 'getHeight' from dom-lib returns 0 in that case and rowHeight is using to calculate nextContentHeight. It works fine for numbers, but fails for functions.