### PR TITLE
feat(Table): add support for wordWrap property values

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ const App = () => (
 | sortType                 | enum: 'desc', 'asc'                                                | Sort type (Controlled)                                                                                                              |
 | virtualized              | boolean                                                            | Effectively render large tabular data                                                                                               |
 | width                    | number                                                             | Table width                                                                                                                         |
+| wordWrap                 | boolean,'break-all','break-word','keep-all'                        | Whether to appear line breaks where text overflows its content box.                                                                 |
 
 ### `<Column>`
 

--- a/docs/data/users.ts
+++ b/docs/data/users.ts
@@ -4,7 +4,8 @@ export default [
     avartar: 'https://s3.amazonaws.com/uifaces/faces/twitter/justinrob/128.jpg',
     city: 'New Amieshire',
     email: 'Leora13@yahoo.com',
-    firstName: 'Ernest Schuppe SchuppeSchuppeSchuppeSchuppeSchuppeSchuppe Schuppe',
+    firstName:
+      'Red Wacky League AntlezBroketheStereoNeon Kitching Josh Bennett Evolution Dreams 红色古怪联盟丹尼尔梅斯马修',
     lastName: 'Schuppe',
     street: 'Ratke Port',
     zipCode: '17026-3154',

--- a/docs/md/WordWrapTable.md
+++ b/docs/md/WordWrapTable.md
@@ -5,6 +5,7 @@
 ```js
 const App = () => {
   const [data, setData] = React.useState(fakeData);
+  const [wordWrap, setWordWrap] = React.useState('break-all');
   return (
     <div>
       <button
@@ -22,9 +23,27 @@ const App = () => {
       >
         Reset
       </button>
+      <select
+        value={wordWrap}
+        onChange={e => {
+          let value = e.target.value;
+
+          if (value === '' || value == 'true') {
+            value = Boolean(value);
+          }
+
+          setWordWrap(value);
+        }}
+      >
+        <option value="">false</option>
+        <option value={true}>true</option>
+        <option value="break-all">break-all</option>
+        <option value="break-word">break-word</option>
+        <option value="keep-all">keep-all</option>
+      </select>
       <hr />
       <Table
-        wordWrap
+        wordWrap={wordWrap}
         height={400}
         data={data}
         onRowClick={data => {
@@ -36,7 +55,7 @@ const App = () => {
           <Cell dataKey="id" />
         </Column>
 
-        <Column width={130} fixed flexGrow={1}>
+        <Column width={140} fixed>
           <HeaderCell>First Name</HeaderCell>
           <Cell dataKey="firstName" />
         </Column>

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -38,7 +38,7 @@ export interface InnerCellProps extends CellProps {
   rowKey?: string | number;
   rowSpan?: number;
   depth?: number;
-  wordWrap?: boolean;
+  wordWrap?: boolean | 'break-all' | 'break-word' | 'keep-all';
   removed?: boolean;
   treeCol?: boolean;
   expanded?: boolean;
@@ -146,6 +146,11 @@ const Cell = React.forwardRef((props: InnerCellProps, ref: React.Ref<HTMLDivElem
     contentStyles.verticalAlign = verticalAlign;
   }
 
+  if (wordWrap) {
+    contentStyles.wordBreak = typeof wordWrap === 'boolean' ? 'break-all' : wordWrap;
+    contentStyles.overflowWrap = wordWrap === 'break-word' ? wordWrap : undefined;
+  }
+
   let cellContent = isNil(children) && rowData && dataKey ? get(rowData, dataKey) : children;
 
   if (typeof children === 'function') {
@@ -228,7 +233,7 @@ Cell.propTypes = {
   onTreeToggle: PropTypes.func,
   renderTreeToggle: PropTypes.func,
   renderCell: PropTypes.func,
-  wordWrap: PropTypes.bool,
+  wordWrap: PropTypes.any,
   removed: PropTypes.bool,
   treeCol: PropTypes.bool,
   expanded: PropTypes.bool

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -174,8 +174,11 @@ export interface TableProps extends Omit<StandardProps, 'onScroll'> {
   /** The width of the table. When it is not set, it will adapt according to the container */
   width?: number;
 
-  /** The cell wraps automatically */
-  wordWrap?: boolean;
+  /**
+   * Whether to appear line breaks where text overflows its content box
+   * https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
+   */
+  wordWrap?: boolean | 'break-all' | 'break-word' | 'keep-all';
 
   /** Effectively render large tabular data */
   virtualized?: boolean;
@@ -1130,7 +1133,7 @@ Table.propTypes = {
   showHeader: PropTypes.bool,
   shouldUpdateScroll: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
   translate3d: PropTypes.bool,
-  wordWrap: PropTypes.bool,
+  wordWrap: PropTypes.any,
   width: PropTypes.number,
   virtualized: PropTypes.bool,
   isTree: PropTypes.bool,

--- a/src/less/table.less
+++ b/src/less/table.less
@@ -162,9 +162,7 @@
   }
 
   &-word-wrap &-cell-content {
-    white-space: unset;
-    word-break: break-all;
-    word-wrap: break-word;
+    white-space: normal;
   }
 
   &-row-expanded {

--- a/src/utils/useTableRows.ts
+++ b/src/utils/useTableRows.ts
@@ -7,7 +7,7 @@ import { RowDataType, RowKeyType } from '../@types/common';
 
 interface TableRowsProps {
   prefix: (str: string) => string;
-  wordWrap: boolean | undefined;
+  wordWrap?: boolean | 'break-all' | 'break-word' | 'keep-all';
   data: RowDataType[];
   expandedRowKeys: RowKeyType[];
 }

--- a/test/TableSpec.js
+++ b/test/TableSpec.js
@@ -164,7 +164,9 @@ describe('Table', () => {
 
     const table = ref.current.root;
     const cell = table.querySelectorAll('.rs-table-cell')[1];
+    const cellContent = table.querySelectorAll('.rs-table-cell-content')[1];
 
+    assert.equal(cellContent.style.wordBreak, 'break-all');
     assert.include(ref.current.root.className, 'rs-table-word-wrap');
 
     setTimeout(() => {
@@ -172,6 +174,60 @@ describe('Table', () => {
       assert.equal(cell.innerText, 'South Georgia and the South Sandwich Islands');
       done();
     }, 1);
+  });
+
+  it('Should be wordWrap=break-all', () => {
+    const ref = React.createRef();
+    render(
+      <Table
+        wordWrap="break-all"
+        data={[{ id: 1, country: 'South Georgia and the South Sandwich Islands' }]}
+      >
+        <Column width={20}>
+          <HeaderCell>Country</HeaderCell>
+          <Cell dataKey="country" ref={ref} />
+        </Column>
+      </Table>
+    );
+
+    const cellContent = ref.current.querySelector('.rs-table-cell-content');
+    assert.equal(cellContent.style.wordBreak, 'break-all');
+  });
+
+  it('Should be wordWrap=break-word', () => {
+    const ref = React.createRef();
+    render(
+      <Table
+        wordWrap="break-word"
+        data={[{ id: 1, country: 'South Georgia and the South Sandwich Islands' }]}
+      >
+        <Column width={20}>
+          <HeaderCell>Country</HeaderCell>
+          <Cell dataKey="country" ref={ref} />
+        </Column>
+      </Table>
+    );
+
+    const cellContent = ref.current.querySelector('.rs-table-cell-content');
+    assert.equal(cellContent.style.wordBreak, 'break-word');
+  });
+
+  it('Should be wordWrap=keep-all', () => {
+    const ref = React.createRef();
+    render(
+      <Table
+        wordWrap="keep-all"
+        data={[{ id: 1, country: 'South Georgia and the South Sandwich Islands' }]}
+      >
+        <Column width={20}>
+          <HeaderCell>Country</HeaderCell>
+          <Cell dataKey="country" ref={ref} />
+        </Column>
+      </Table>
+    );
+
+    const cellContent = ref.current.querySelector('.rs-table-cell-content');
+    assert.equal(cellContent.style.wordBreak, 'keep-all');
   });
 
   it('Should be wordWrap when isTree', done => {


### PR DESCRIPTION
```ts
 wordWrap?: boolean | 'break-all' | 'break-word' | 'keep-all';
```

> https://developer.mozilla.org/en-US/docs/Web/CSS/word-break