### PR TITLE
Make rowspan cell clickable

### DIFF
--- a/src/less/table.less
+++ b/src/less/table.less
@@ -13,6 +13,9 @@
     height: 36px;
     width: 100%;
     top: 0;
+    &-rowspan {
+      z-index: 1;
+    }
   }
 
   &-hover &-row:hover {


### PR DESCRIPTION
Currently the cells spanning across rows are not clickable outside of its natural row, due to it being nested within row containers. This PR fixes that.

![image](https://user-images.githubusercontent.com/13040517/183090008-027a2c07-760b-4a34-822e-a67c5b6efd0f.png)

