### PR TITLE
refactor: mark array arguments as readonly where they wont be modified

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -53,7 +53,11 @@ import type {
  * @param rowKey
  * @returns
  */
-const filterTreeData = (data: any[], expandedRowKeys: RowKeyType[], rowKey?: RowKeyType) => {
+const filterTreeData = (
+  data: readonly any[],
+  expandedRowKeys: RowKeyType[],
+  rowKey?: RowKeyType
+) => {
   return flattenData(data).filter(rowData => {
     if (rowKey) {
       const parents = findAllParents(rowData, rowKey);
@@ -105,7 +109,7 @@ export interface TableProps extends Omit<StandardProps, 'onScroll'> {
   defaultExpandedRowKeys?: RowKeyType[];
 
   /** Table data */
-  data?: RowDataType[];
+  data?: readonly RowDataType[];
 
   /** Specify the default expanded row by  rowkey (Controlled) */
   expandedRowKeys?: RowKeyType[];

--- a/src/utils/findRowKeys.ts
+++ b/src/utils/findRowKeys.ts
@@ -1,6 +1,10 @@
 import { RowKeyType, RowDataType } from '../@types/common';
 
-export default function findRowKeys(rows: RowDataType[], rowKey?: RowKeyType, expanded?: boolean) {
+export default function findRowKeys(
+  rows: readonly RowDataType[],
+  rowKey?: RowKeyType,
+  expanded?: boolean
+) {
   let keys: RowKeyType[] = [];
 
   if (!rowKey) {

--- a/src/utils/flattenData.ts
+++ b/src/utils/flattenData.ts
@@ -6,7 +6,7 @@ import type { RowDataType } from '../@types/common';
  * @param treeData
  * @returns
  */
-function flattenData(treeData: RowDataType[]) {
+function flattenData(treeData: readonly RowDataType[]) {
   const flattenItems: RowDataType[] = [];
 
   function loop(treeData, parentNode) {

--- a/src/utils/usePosition.ts
+++ b/src/utils/usePosition.ts
@@ -7,7 +7,7 @@ import type { RowDataType } from '../@types/common';
 import isSupportTouchEvent from './isSupportTouchEvent';
 
 interface PositionProps {
-  data: RowDataType[];
+  data: readonly RowDataType[];
   height: number;
   tableWidth: React.MutableRefObject<number>;
   tableRef: React.RefObject<HTMLDivElement>;

--- a/src/utils/useScrollListener.ts
+++ b/src/utils/useScrollListener.ts
@@ -20,7 +20,7 @@ const momentumYThreshold = 15;
 
 interface ScrollListenerProps {
   rtl: boolean;
-  data: RowDataType[];
+  data: readonly RowDataType[];
   height: number;
   getTableHeight: () => number;
   contentHeight: React.MutableRefObject<number>;

--- a/src/utils/useTableDimension.ts
+++ b/src/utils/useTableDimension.ts
@@ -10,7 +10,7 @@ import isNumberOrTrue from './isNumberOrTrue';
 import { RowDataType, RowKeyType, ElementOffset } from '../@types/common';
 
 interface TableDimensionProps {
-  data?: RowDataType[];
+  data?: readonly RowDataType[];
   rowHeight?: number | ((rowData: RowDataType) => number);
   height: number;
   minHeight: number;

--- a/src/utils/useTableRows.ts
+++ b/src/utils/useTableRows.ts
@@ -8,7 +8,7 @@ import { RowDataType, RowKeyType } from '../@types/common';
 interface TableRowsProps {
   prefix: (str: string) => string;
   wordWrap?: boolean | 'break-all' | 'break-word' | 'keep-all';
-  data: RowDataType[];
+  data: readonly RowDataType[];
   expandedRowKeys: RowKeyType[];
 }
 


### PR DESCRIPTION
Mark `data` prop of Table as readonly array so that readonly arrays can fit.

<img width="442" alt="image" src="https://user-images.githubusercontent.com/8225666/185310544-6758f36f-ae24-4efa-97cb-430ebfc4c50a.png">
<img width="663" alt="image" src="https://user-images.githubusercontent.com/8225666/185310637-5b9ac771-7094-4795-858b-12c2aba31442.png">
