### PR TITLE
fix(autoHeight): fixed scroll event not updating after autoHeight value changed

### DIFF
--- a/docs/md/AutoHeightTable.md
+++ b/docs/md/AutoHeightTable.md
@@ -5,7 +5,7 @@
 ```js
 const App = () => {
   const [size, setSize] = React.useState(fakeData.length);
-  const [autoHeight, setAutoHeight] = React.useState(false);
+  const [autoHeight, setAutoHeight] = React.useState(true);
 
   const data = fakeData.filter((item, index) => index < size);
   return (

--- a/src/utils/useScrollListener.ts
+++ b/src/utils/useScrollListener.ts
@@ -133,7 +133,7 @@ const useScrollListener = (props: ScrollListenerProps) => {
 
   const shouldHandleWheelY = useCallback(
     (delta: number) => {
-      if (delta === 0 || disabledScroll || loading) {
+      if (delta === 0 || disabledScroll || loading || autoHeight) {
         return false;
       }
 
@@ -143,7 +143,7 @@ const useScrollListener = (props: ScrollListenerProps) => {
         );
       }
     },
-    [disabledScroll, loading, minScrollY, scrollY]
+    [autoHeight, disabledScroll, loading, minScrollY, scrollY]
   );
 
   const debounceScrollEndedCallback = useCallback(() => {


### PR DESCRIPTION
The value of autoHeight changing from false to true after the Table is mounted will cause the scroll event not to update, and vertical scrolling will still work, but it should be blocked.