### PR TITLE
fix: reset columnWidths ref when children change in useCellDescriptor

### DIFF
--- a/src/utils/useCellDescriptor.ts
+++ b/src/utils/useCellDescriptor.ts
@@ -92,6 +92,10 @@ const useCellDescriptor = (props: CellDescriptorProps): CellDescriptor => {
     clearCache();
   }, [children, sortColumn, sortType, tableWidth.current, scrollX.current, minScrollX.current]);
 
+  useUpdateEffect(() => {
+    columnWidths.current = {};
+  }, [children]);
+
   const handleColumnResizeEnd = useCallback(
     (columnWidth: number, _cursorDelta: number, dataKey: any, index: number) => {
       columnWidths.current[`${dataKey}_${index}_width`] = columnWidth;

--- a/test/useCellDescriptorSpec.js
+++ b/test/useCellDescriptorSpec.js
@@ -1,0 +1,98 @@
+import React, { useEffect, useState, useMemo } from 'react';
+import ReactTestUtils, { act } from 'react-dom/test-utils';
+import useCellDescriptor from '../src/utils/useCellDescriptor';
+import Column from '../src/Column';
+import HeaderCell from '../src/HeaderCell';
+import Cell from '../src/Cell';
+
+describe('useCellDescriptor', () => {
+  let cellDescriptor;
+  let setWidthOfFirstColumn;
+
+  // test component that wraps useCellDescriptor and stores ref to
+  // output vars in the `cellDescriptor` var declared above
+  const TestComponent = () => {
+    const [width, setWidth] = useState(100);
+    setWidthOfFirstColumn = setWidth;
+
+    const columns = useMemo(
+      () => [
+        <Column width={width} key="col1" resizable>
+          <HeaderCell></HeaderCell>
+          <Cell dataKey="key1"></Cell>
+        </Column>,
+        <Column width={200} key="col2">
+          <HeaderCell></HeaderCell>
+          <Cell dataKey="key2"></Cell>
+        </Column>
+      ],
+      [width]
+    );
+
+    const descriptor = useCellDescriptor({
+      children: columns,
+      showHeader: true,
+      headerHeight: 100,
+      tableRef: {},
+      tableWidth: {},
+      scrollX: {},
+      minScrollX: {},
+      mouseAreaRef: {}
+    });
+
+    useEffect(() => {
+      cellDescriptor = descriptor;
+    }, [descriptor]);
+
+    return null;
+  };
+
+  it('Should output expected vars', () => {
+    act(() => ReactTestUtils.renderIntoDocument(<TestComponent />));
+
+    assert.containsAllKeys(cellDescriptor, [
+      'columns',
+      'headerCells',
+      'bodyCells',
+      'allColumnsWidth',
+      'hasCustomTreeCol'
+    ]);
+  });
+
+  it('Should set widths on cells', () => {
+    act(() => ReactTestUtils.renderIntoDocument(<TestComponent />));
+
+    const { headerCells, bodyCells } = cellDescriptor;
+
+    assert.equal(headerCells[0].props.width, 100);
+    assert.equal(bodyCells[0].props.width, 100);
+    assert.equal(headerCells[1].props.width, 200);
+    assert.equal(headerCells[1].props.width, 200);
+  });
+
+  it('Should update cell width on column resize', () => {
+    act(() => ReactTestUtils.renderIntoDocument(<TestComponent />));
+
+    const { headerCells } = cellDescriptor;
+    const { onColumnResizeEnd } = headerCells[0].props;
+
+    // (columnWidth: number, _cursorDelta: number, dataKey: any, index: number)
+    act(() => onColumnResizeEnd(500, 5, 'key1', 0));
+
+    assert.equal(cellDescriptor.bodyCells[0].props.width, 500);
+  });
+
+  it('Should set proper cell width on column resize followed by column width change', () => {
+    act(() => ReactTestUtils.renderIntoDocument(<TestComponent />));
+
+    const { headerCells } = cellDescriptor;
+    const { onColumnResizeEnd } = headerCells[0].props;
+
+    // (columnWidth: number, _cursorDelta: number, dataKey: any, index: number)
+    act(() => onColumnResizeEnd(500, 5, 'key1', 0));
+    assert.equal(cellDescriptor.bodyCells[0].props.width, 500);
+
+    act(() => setWidthOfFirstColumn(420));
+    assert.equal(cellDescriptor.bodyCells[0].props.width, 420);
+  });
+});


### PR DESCRIPTION
Hi,

First off, thanks for a great table component.

We're using rsuite-table in kinda complex data table based experiences.
As part of these experiences one of our features control column widths through controls that are external to the table component (i.e. not through the resize handler). 

The problem we're facing is that if a user changes the width of a column by using the column resize handler, then takes some action elsewhere which causes the column's width to change (i.e. re-rendered with different prop), the updated `column.width` prop that is passed to rsuite-table will not be honored. This happens due to the caching of column widths within rsuite-table which kicks in once the resize handler is used.

The caching probably makes perfect sense in most cases, but for our use case it creates a case where if a user has changed a column manually, that manual column width will persist within rsuite-table until the page is reloaded (changing the value of the `width` prop passed to the the column does not have any effect).

I managed to get around this by making the changes that are included in this PR. 
These changes would make it possible for us to treat certain "states" of columns differently, but I am not sure if it is the best approach. 

If this seems fine I can update the PR with tests, if not PLMK if there's some other approach that could work and I can look into making necessary changes (if any).

And feel free to LMK if more info is needed, of course.

Thanks
Trond