### PR TITLE
fix(Table): translate3d disabled by default

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -288,7 +288,7 @@ const Table = React.forwardRef(<Row extends RowDataType, Key>(props: TableProps<
     autoHeight,
     fillHeight,
     rtl: rtlProp,
-    translate3d = true,
+    translate3d = false,
     rowKey,
     virtualized,
     rowClassName,

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -288,7 +288,7 @@ const Table = React.forwardRef(<Row extends RowDataType, Key>(props: TableProps<
     autoHeight,
     fillHeight,
     rtl: rtlProp,
-    translate3d = false,
+    translate3d,
     rowKey,
     virtualized,
     rowClassName,


### PR DESCRIPTION
translate3d causes multiple rendering issues when enabled.

https://github.com/rsuite/rsuite-table/issues/98
https://github.com/rsuite/rsuite/issues/1038
https://github.com/rsuite/rsuite-table/issues/256
https://github.com/rsuite/rsuite-table/issues/355
https://github.com/rsuite/rsuite/issues/2648
https://github.com/rsuite/rsuite/discussions/3122