### PR TITLE
Feat(column): add support for flexGrow with resizable

### DIFF
--- a/docs/examples/ResizableColumnTable.md
+++ b/docs/examples/ResizableColumnTable.md
@@ -30,7 +30,7 @@ const App = () => {
         <Cell dataKey="lastName" />
       </Column>
 
-      <Column width={200} resizable>
+      <Column width={200} resizable flexGrow={1}>
         <HeaderCell>City</HeaderCell>
         <Cell dataKey="city" />
       </Column>

--- a/src/utils/useCellDescriptor.ts
+++ b/src/utils/useCellDescriptor.ts
@@ -216,9 +216,15 @@ const useCellDescriptor = <Row extends RowDataType>(
       let cellWidth = currentWidth || width || 0;
 
       if (tableWidth.current && flexGrow && totalFlexGrow) {
-        cellWidth =
-          currentWidth ||
-          Math.max(((tableWidth.current - totalWidth) / totalFlexGrow) * flexGrow, minWidth || 60);
+        const grewWidth = Math.max(
+          ((tableWidth.current - totalWidth) / totalFlexGrow) * flexGrow,
+          minWidth || 60
+        );
+        /**
+         * resizable = false, width will be recalc when table render.
+         * resizable = true, only first render will use grewWidth.
+         */
+        cellWidth = resizable ? currentWidth || grewWidth : grewWidth;
       }
 
       const cellProps = {

--- a/src/utils/useCellDescriptor.ts
+++ b/src/utils/useCellDescriptor.ts
@@ -204,12 +204,6 @@ const useCellDescriptor = <Row extends RowDataType>(
         hasCustomTreeCol = true;
       }
 
-      if (resizable && flexGrow) {
-        console.warn(
-          `Cannot set 'resizable' and 'flexGrow' together in <Column>, column index: ${index}`
-        );
-      }
-
       if (columnChildren.length !== 2) {
         throw new Error(`Component <HeaderCell> and <Cell> is required, column index: ${index} `);
       }

--- a/src/utils/useCellDescriptor.ts
+++ b/src/utils/useCellDescriptor.ts
@@ -217,13 +217,14 @@ const useCellDescriptor = <Row extends RowDataType>(
       const headerCell = columnChildren[0] as React.ReactElement<CellProps>;
       const cell = columnChildren[1] as React.ReactElement<CellProps>;
 
-      let cellWidth = columnWidths.current?.[`${cell.props.dataKey}_${index}_width`] || width || 0;
+      const currentWidth = columnWidths.current?.[`${cell.props.dataKey}_${index}_width`];
+
+      let cellWidth = currentWidth || width || 0;
 
       if (tableWidth.current && flexGrow && totalFlexGrow) {
-        cellWidth = Math.max(
-          ((tableWidth.current - totalWidth) / totalFlexGrow) * flexGrow,
-          minWidth || 60
-        );
+        cellWidth =
+          currentWidth ||
+          Math.max(((tableWidth.current - totalWidth) / totalFlexGrow) * flexGrow, minWidth || 60);
       }
 
       const cellProps = {
@@ -250,7 +251,7 @@ const useCellDescriptor = <Row extends RowDataType>(
           onSortColumn: handleSortColumn,
           sortType,
           sortColumn,
-          flexGrow
+          flexGrow: resizable ? undefined : flexGrow
         };
 
         if (resizable) {

--- a/test/TableSpec.js
+++ b/test/TableSpec.js
@@ -1366,4 +1366,30 @@ describe('Table', () => {
     expect(instance.querySelector('.rs-table-cell-header-sortable')).to.exist;
     expect(instance.querySelector('.rs-table-cell-full-text')).to.not.exist;
   });
+
+  it('Should render ColumnResizer & fill rest space', () => {
+    const instance = getDOMNode(
+      <Table
+        data={[
+          {
+            id: 1,
+            name: 'a'
+          }
+        ]}
+      >
+        <Column width={100} flexGrow={1} resizable>
+          <HeaderCell>Name</HeaderCell>
+          <Cell dataKey="name" />
+        </Column>
+      </Table>
+    );
+
+    const headerCell = instance.querySelector('.rs-table-cell-header');
+    expect(headerCell).to.exist;
+    expect(instance.querySelector('.rs-table-column-resize-spanner')).to.exist;
+
+    const width = headerCell.getBoundingClientRect().width;
+    expect(width).not.equal(100);
+    expect(width).to.equal(instance.getBoundingClientRect().width);
+  });
 });


### PR DESCRIPTION
## Feature

this pull request enables the user to define both `resizable` and `flexGrow` properties within a single column

## Current Behavior

defining both of these properties within the same column results in the column being incapable of resizing and failing to fill the remaining space.

## Expectation

the column needs to be both resizable and fill up any remaining space.

### without `flexGrow`

there are empty space in the right

![Screenshot 2023-06-25 at 18 43 14](https://github.com/rsuite/rsuite-table/assets/14308293/3d9ab6f1-c415-4b9f-b2b7-3401c32e3955)

### add `flexGrow={1}`

```tsx
 <Column width={200} resizable flexGrow={1}>
   <HeaderCell>City</HeaderCell>
   <Cell dataKey="city" />
</Column>
```

`city` column fills remaining space with no empty space on the right.

![Screenshot 2023-06-25 at 18 44 05](https://github.com/rsuite/rsuite-table/assets/14308293/d8842bdd-49ff-4771-b219-b125785b82ce)

