### PR TITLE
[column]: fix column width reset after children update

### DIFF
--- a/docs/examples/ResizableColumnTable.md
+++ b/docs/examples/ResizableColumnTable.md
@@ -6,6 +6,8 @@
 const data = mockUsers(20);
 
 const App = () => {
+  const [width, setWidth] = React.useState(200);
+
   return (
     <Table bordered height={400} data={data}>
       <Column width={50} align="center" fixed>
@@ -30,7 +32,7 @@ const App = () => {
         <Cell dataKey="lastName" />
       </Column>
 
-      <Column width={200} resizable flexGrow={1}>
+      <Column width={width} resizable flexGrow={1} onResize={width => setWidth(width)}>
         <HeaderCell>City</HeaderCell>
         <Cell dataKey="city" />
       </Column>

--- a/docs/examples/ResizableColumnTable.md
+++ b/docs/examples/ResizableColumnTable.md
@@ -6,7 +6,7 @@
 const data = mockUsers(20);
 
 const App = () => {
-  const [width, setWidth] = React.useState(200);
+  const [width, setWidth] = React.useState(null);
 
   return (
     <Table bordered height={400} data={data}>
@@ -37,7 +37,7 @@ const App = () => {
         <Cell dataKey="city" />
       </Column>
 
-      <Column width={200} resizable>
+      <Column width={200} resizable flexGrow={1}>
         <HeaderCell>Street</HeaderCell>
         <Cell dataKey="street" />
       </Column>

--- a/src/utils/useCellDescriptor.ts
+++ b/src/utils/useCellDescriptor.ts
@@ -222,6 +222,8 @@ const useCellDescriptor = <Row extends RowDataType>(
 
       let cellWidth = currentWidth || width || 0;
 
+      const isControlled = typeof width === 'number' && typeof onResize === 'function';
+
       /**
        * in resizable mode,
        *    if width !== initialColumnWidth, use current column width and update cache.
@@ -257,7 +259,7 @@ const useCellDescriptor = <Row extends RowDataType>(
         left,
         headerHeight,
         key: index,
-        width: cellWidth,
+        width: isControlled ? width : cellWidth,
         height: typeof rowHeight === 'function' ? rowHeight() : rowHeight,
         firstColumn: index === 0,
         lastColumn: index === count - 1

--- a/src/utils/useCellDescriptor.ts
+++ b/src/utils/useCellDescriptor.ts
@@ -91,6 +91,12 @@ const useCellDescriptor = <Row extends RowDataType>(
     [prefix, tableRef]
   );
 
+  /**
+   * storage column width from props.
+   * if current column width not equal initial column width, use current column width and update cache.
+   */
+  const initialColumnWidths = useRef({});
+
   const columnWidths = useRef({});
 
   useMount(() => {
@@ -101,10 +107,6 @@ const useCellDescriptor = <Row extends RowDataType>(
   useUpdateEffect(() => {
     clearCache();
   }, [children, sortColumn, sortType, tableWidth.current, scrollX.current, minScrollX.current]);
-
-  useUpdateEffect(() => {
-    columnWidths.current = {};
-  }, [children]);
 
   const handleColumnResizeEnd = useCallback(
     (columnWidth: number, _cursorDelta: number, dataKey: any, index: number) => {
@@ -211,9 +213,31 @@ const useCellDescriptor = <Row extends RowDataType>(
       const headerCell = columnChildren[0] as React.ReactElement<CellProps>;
       const cell = columnChildren[1] as React.ReactElement<CellProps>;
 
-      const currentWidth = columnWidths.current?.[`${cell.props.dataKey}_${index}_width`];
+      const cellWidthId = `${cell.props.dataKey}_${index}_width`;
+
+      // get column width from cache.
+      const initialColumnWidth = initialColumnWidths.current?.[cellWidthId];
+
+      const currentWidth = columnWidths.current?.[cellWidthId];
 
       let cellWidth = currentWidth || width || 0;
+
+      /**
+       * in resizable mode,
+       *    if width !== initialColumnWidth, use current column width and update cache.
+       */
+      if (resizable && (initialColumnWidth || width) && initialColumnWidth !== width) {
+        // initial or update initialColumnWidth cache.
+        initialColumnWidths.current[cellWidthId] = width;
+        /**
+         * if currentWidth exist, update columnWidths cache.
+         */
+        if (currentWidth) {
+          columnWidths.current[cellWidthId] = width;
+          // update cellWidth
+          cellWidth = width;
+        }
+      }
 
       if (tableWidth.current && flexGrow && totalFlexGrow) {
         const grewWidth = Math.max(


### PR DESCRIPTION
## CHANGES

1. Implemented resizable column width feature, allowing users to control the width of columns as needed.

2. Fixed the issue where column width was being reset after updating the contents of the column's children, ensuring that column resizing remains consistent.

3. If both `width` and `onResize` are valid, the column will be fully controlled, and `flexGrow` will no longer affect the result.

## :boom: Breaking Change 

Setting `width` as a fixed number (e.g., number literal `100`) along with `resizable` and `onResize` simultaneously will make the column width unchangeable.

```tsx
<Table.Column
  width={100} // you cant resize it anymore
  resizable
  onResize={(width) => {
    // do something
  }}
>
  <Table.HeaderCell>name</Table.HeaderCell>
  <Table.Cell dataKey="name" />
</Table.Column>
```

### Example For `Unontrolled` to `Controlled` with `flexGrow`

```jsx
function App() {
  // initial value is undefined, so flexGrow worked 
  const [width, setWidth] = useState();

  return (
    <Table>
      <Table.Column
        width={width}
        resizable
        flexGrow={1}
        onResize={width => {
          // after user resizes the column, store the new width in state
          setWidth(width);
        }}
      >
        <Table.HeaderCell>name</Table.HeaderCell>
        <Table.Cell dataKey="name" />
      </Table.Column>
    </Table>
  );
}
```

## related

this PR also related to #364

close #445