### PR TITLE
Fix type extension

### DIFF
--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -9,7 +9,7 @@ import ColumnResizeHandler, { FixedType } from './ColumnResizeHandler';
 import { useUpdateEffect, useClassNames } from './utils';
 import Cell, { InnerCellProps } from './Cell';
 
-export interface HeaderCellProps extends InnerCellProps {
+export interface HeaderCellProps extends Omit<InnerCellProps, 'onResize'> {
   index?: number;
   minWidth?: number;
   sortColumn?: string;


### PR DESCRIPTION
```
node_modules/rsuite-table/lib/HeaderCell.d.ts:4:18 - error TS2430: Interface 'HeaderCellProps' incorrectly extends interface 'InnerCellProps'.
  Types of property 'onResize' are incompatible.
    Type '((columnWidth?: number | undefined, dataKey?: string | undefined) => void) | undefined' is not assignable to type 'ReactEventHandler<HTMLElement> | undefined'.
      Type '(columnWidth?: number | undefined, dataKey?: string | undefined) => void' is not assignable to type 'ReactEventHandler<HTMLElement>'.
        Types of parameters 'columnWidth' and 'event' are incompatible.
          Type 'SyntheticEvent<HTMLElement, Event>' is not assignable to type 'number'.

4 export interface HeaderCellProps extends InnerCellProps {
                   ~~~~~~~~~~~~~~~
```