### PR TITLE
ci: test types

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -13,6 +13,35 @@ on:
       - main
       - next
 jobs:
+  test-types:
+    name: 'Test Types'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: pnpm/action-setup@v2.0.1
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 7.3.0
+
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: '16.x'
+      - name: Cache Node.js modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.OS }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.OS }}-node-
+            ${{ runner.OS }}-
+      - name: Install dependencies
+        run: pnpm i
+      - name: Run tests
+        run: npm run test:types
+
   test:
     name: 'Test'
 


### PR DESCRIPTION
At the moment, types aren't checked and there are errors present in the current code. The types should be checked automatically.

UPD: looks like the errors are there only if I use `npm install` instead of `pnpm`. Anyway, this should be included to CI pipeline.

UPD2: oh I see it's included already.