### PR TITLE
fix(TreeTable): fix incorrect scrolling position of tree nodes after collapse

### DIFF
--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -417,7 +417,9 @@ const Table = React.forwardRef(<Row extends RowDataType, Key>(props: TableProps<
     setScrollX,
     getTableHeight
   } = useTableDimension({
-    data: dataProp,
+    // The data should be flattened,
+    // otherwise the array length required to calculate the scroll height in the TreeTable is not real.
+    data,
     width: widthProp,
     rowHeight,
     tableRef,


### PR DESCRIPTION
fix: https://github.com/rsuite/rsuite-table/issues/443
fix: https://github.com/rsuite/rsuite-table/issues/438