### PR TITLE
Issue 3412:- added a list of arrowKeys, added a check for only required events in …

### DIFF
--- a/src/utils/useScrollListener.ts
+++ b/src/utils/useScrollListener.ts
@@ -20,6 +20,10 @@ const momentumTimeThreshold = 300;
 // Inertial sliding start vertical distance threshold
 const momentumYThreshold = 15;
 
+//List of Arrow Keys for scrolling through keys
+const arrowKeysList = ['ArrowUp', "ArrowDown", "ArrowLeft", "ArrowRight"]
+
+
 interface ScrollListenerProps {
   rtl: boolean;
   data: readonly RowDataType[];
@@ -506,7 +510,7 @@ const useScrollListener = (props: ScrollListenerProps) => {
 
   const onScrollByKeydown = useCallback(
     (event: React.KeyboardEvent) => {
-      if (event.currentTarget === event.target) {
+      if (event.currentTarget === event.target && arrowKeysList.indexOf(event.key) > -1 ) {
         event.preventDefault();
         const step = 40;
 

--- a/src/utils/useScrollListener.ts
+++ b/src/utils/useScrollListener.ts
@@ -21,8 +21,7 @@ const momentumTimeThreshold = 300;
 const momentumYThreshold = 15;
 
 //List of Arrow Keys for scrolling through keys
-const arrowKeysList = ['ArrowUp', "ArrowDown", "ArrowLeft", "ArrowRight"]
-
+const arrowKeysList = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'];
 
 interface ScrollListenerProps {
   rtl: boolean;
@@ -510,7 +509,7 @@ const useScrollListener = (props: ScrollListenerProps) => {
 
   const onScrollByKeydown = useCallback(
     (event: React.KeyboardEvent) => {
-      if (event.currentTarget === event.target && arrowKeysList.indexOf(event.key) > -1 ) {
+      if (event.currentTarget === event.target && arrowKeysList.indexOf(event.key) > -1) {
         event.preventDefault();
         const step = 40;
 


### PR DESCRIPTION
Resolution of issue.
[https://github.com/rsuite/rsuite/issues/3412](https://github.com/rsuite/rsuite/issues/3412)

This issue is caused by the onScrollByKeyDown functionality introduced in the recent release.
It captures all key events and for all keystrokes, it prevents them from performing their default operation

**added a list of arrowKeys, and added a check for only required events in the onScrollByKeydown function.**
