### PR TITLE
refactor: remove propTypes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,8 +30,7 @@ module.exports = {
     '@typescript-eslint/explicit-member-accessibility': OFF,
     '@typescript-eslint/no-namespace': OFF,
     '@typescript-eslint/explicit-module-boundary-types': OFF,
-    'react/display-name': OFF,
-    'react/prop-types': OFF
+    'react/display-name': OFF
   },
   settings: {
     react: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -62,7 +62,6 @@ module.exports = config => {
     frameworks: ['mocha', 'chai-dom', 'sinon-chai', 'webpack'],
     colors: true,
     reporters: ['mocha', 'coverage'],
-
     logLevel: config.LOG_INFO,
     preprocessors: {
       'test/*.js': ['webpack']

--- a/package.json
+++ b/package.json
@@ -41,16 +41,14 @@
   "dependencies": {
     "@babel/runtime": "^7.12.5",
     "@juggle/resize-observer": "^3.3.1",
-    "@rsuite/icons": "^1.0.0",
+    "@rsuite/icons": "^1.3.0",
     "classnames": "^2.3.1",
     "dom-lib": "^3.3.1",
-    "lodash": "^4.17.21",
-    "react-is": "^17.0.2"
+    "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "prop-types": "^15.7.2",
-    "react": ">=16.8.0",
-    "react-dom": ">=16.8.0"
+    "react": ">=18",
+    "react-dom": ">=18"
   },
   "devDependencies": {
     "@babel/cli": "^7.12.8",
@@ -70,10 +68,8 @@
     "@faker-js/faker": "^7.6.0",
     "@testing-library/react": "^13.4.0",
     "@types/lodash": "^4.14.165",
-    "@types/prop-types": "^15.7.1",
-    "@types/react": "^18.0.17",
-    "@types/react-dom": "^18.0.6",
-    "@types/react-is": "^18.2.4",
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^6.9.0",
     "@typescript-eslint/parser": "^6.9.0",
     "autoprefixer": "^8.3.0",
@@ -123,7 +119,6 @@
     "mini-css-extract-plugin": "^2.3.0",
     "mocha": "^9.0.2",
     "prettier": "^2.3.2",
-    "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-code-view": "^2.2.1",
     "react-dnd": "^16.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^3.3.1
         version: 3.4.0
       '@rsuite/icons':
-        specifier: ^1.0.0
-        version: 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^1.3.0
+        version: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       classnames:
         specifier: ^2.3.1
         version: 2.5.1
@@ -26,9 +26,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      react-is:
-        specifier: ^17.0.2
-        version: 17.0.2
     devDependencies:
       '@babel/cli':
         specifier: ^7.12.8
@@ -81,17 +78,11 @@ importers:
       '@types/lodash':
         specifier: ^4.14.165
         version: 4.17.7
-      '@types/prop-types':
-        specifier: ^15.7.1
-        version: 15.7.12
       '@types/react':
-        specifier: ^18.0.17
+        specifier: ^18.2.0
         version: 18.3.4
       '@types/react-dom':
-        specifier: ^18.0.6
-        version: 18.3.0
-      '@types/react-is':
-        specifier: ^18.2.4
+        specifier: ^18.2.0
         version: 18.3.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.9.0
@@ -240,9 +231,6 @@ importers:
       prettier:
         specifier: ^2.3.2
         version: 2.8.8
-      prop-types:
-        specifier: ^15.8.1
-        version: 15.8.1
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -1178,11 +1166,11 @@ packages:
   '@react-dnd/shallowequal@4.0.2':
     resolution: {integrity: sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==}
 
-  '@rsuite/icon-font@4.0.0':
-    resolution: {integrity: sha512-rZTgpTH3H3HLczCA2rnkWfoMKm0ZXoRzsrkVujfP/FfslnKUMvO6w56pa8pCvhWGpNEPUsLS2ULnFGpTEcup/Q==}
+  '@rsuite/icon-font@4.1.0':
+    resolution: {integrity: sha512-q0Y+uQCVvzhD6lFeAFrvCDd1lTjZfM6MIaBjre3lSW1w586VWbuFnhTiqos3v9HIMlUpm3aAsxd3SuM6gYaqqQ==}
 
-  '@rsuite/icons@1.0.3':
-    resolution: {integrity: sha512-qkjYFn1v5YV9eH57Q4AJ8CwsQYfILun2wdoxhQg5+xYxkIu6UyF8vTMmpOzLvcybTE7D8STm4dH7vhpyhPOC7g==}
+  '@rsuite/icons@1.3.0':
+    resolution: {integrity: sha512-6yv2CQjtQGgSCkMw1wlVlmPFEKBTU9AFFFxPJbAI2V4kS9lZEHqhY+jmVSAdbC7rmawO5r2ROzGMJpvkpRCnUw==}
     peerDependencies:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
@@ -1281,9 +1269,6 @@ packages:
 
   '@types/react-dom@18.3.0':
     resolution: {integrity: sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==}
-
-  '@types/react-is@18.3.0':
-    resolution: {integrity: sha512-KZJpHUkAdzyKj/kUHJDc6N7KyidftICufJfOFpiG6haL/BDQNQt5i4n1XDUL/nDZAtGLHDSWRYpLzKTAKSvX6w==}
 
   '@types/react-window@1.8.8':
     resolution: {integrity: sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==}
@@ -3406,7 +3391,7 @@ packages:
     resolution: {integrity: sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==}
     engines: {node: '>= 4.0'}
     os: [darwin]
-    deprecated: The v1 package contains DANGEROUS / INSECURE binaries. Upgrade to safe fsevents v2
+    deprecated: Upgrade to fsevents v2 to mitigate potential security issues
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3896,9 +3881,6 @@ packages:
   inquirer@8.2.5:
     resolution: {integrity: sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==}
     engines: {node: '>=12.0.0'}
-
-  insert-css@2.0.0:
-    resolution: {integrity: sha512-xGq5ISgcUP5cvGkS2MMFLtPDBtrtQPSFfC6gA6U8wHKqfjTIMZLZNxOItQnoSjdOzlXOLU/yD32RKC4SvjNbtA==}
 
   internal-ip@4.3.0:
     resolution: {integrity: sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==}
@@ -8363,15 +8345,12 @@ snapshots:
 
   '@react-dnd/shallowequal@4.0.2': {}
 
-  '@rsuite/icon-font@4.0.0': {}
+  '@rsuite/icon-font@4.1.0': {}
 
-  '@rsuite/icons@1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@rsuite/icons@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@babel/runtime': 7.25.0
-      '@rsuite/icon-font': 4.0.0
+      '@rsuite/icon-font': 4.1.0
       classnames: 2.5.1
-      insert-css: 2.0.0
-      lodash: 4.17.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
@@ -8479,10 +8458,6 @@ snapshots:
   '@types/q@1.5.8': {}
 
   '@types/react-dom@18.3.0':
-    dependencies:
-      '@types/react': 18.3.4
-
-  '@types/react-is@18.3.0':
     dependencies:
       '@types/react': 18.3.4
 
@@ -11811,8 +11786,6 @@ snapshots:
       through: 2.3.8
       wrap-ansi: 7.0.0
 
-  insert-css@2.0.0: {}
-
   internal-ip@4.3.0:
     dependencies:
       default-gateway: 4.2.0
@@ -14160,7 +14133,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.25.0
       '@juggle/resize-observer': 3.4.0
-      '@rsuite/icons': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@rsuite/icons': 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       classnames: 2.5.1
       dom-lib: 3.3.1
       lodash: 4.17.21
@@ -14173,7 +14146,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.25.0
       '@juggle/resize-observer': 3.4.0
-      '@rsuite/icons': 1.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@rsuite/icons': 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/lodash': 4.17.7
       '@types/prop-types': 15.7.12
       '@types/react-window': 1.8.8

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback } from 'react';
-import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
 import isNil from 'lodash/isNil';
 import get from 'lodash/get';
@@ -225,36 +224,6 @@ const Cell = React.forwardRef(
 );
 
 Cell.displayName = 'Table.Cell';
-
-Cell.propTypes = {
-  align: PropTypes.string,
-  verticalAlign: PropTypes.string,
-  className: PropTypes.string,
-  classPrefix: PropTypes.string,
-  dataKey: PropTypes.string,
-  isHeaderCell: PropTypes.bool,
-  width: PropTypes.number,
-  height: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
-  left: PropTypes.number,
-  headerHeight: PropTypes.number,
-  style: PropTypes.object,
-  firstColumn: PropTypes.bool,
-  lastColumn: PropTypes.bool,
-  hasChildren: PropTypes.bool,
-  children: PropTypes.any,
-  rowKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  rowIndex: PropTypes.number,
-  rowData: PropTypes.object,
-  depth: PropTypes.number,
-  onTreeToggle: PropTypes.func,
-  renderTreeToggle: PropTypes.func,
-  renderCell: PropTypes.func,
-  wordWrap: PropTypes.any,
-  removed: PropTypes.bool,
-  treeCol: PropTypes.bool,
-  expanded: PropTypes.bool,
-  fullText: PropTypes.bool
-};
 
 export default Cell as <Row extends RowDataType, Key extends RowKeyType>(
   props: InnerCellProps<Row, Key> & React.RefAttributes<HTMLDivElement>

--- a/src/Column.tsx
+++ b/src/Column.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { RowDataType } from './@types/common';
 
 export interface ColumnProps<Row extends RowDataType> {
@@ -51,31 +50,27 @@ function Column<Row extends RowDataType>(_props: ColumnProps<Row>) {
   return <></>;
 }
 
-const propTypes = {
-  align: PropTypes.string,
-  verticalAlign: PropTypes.string,
-  width: PropTypes.number,
-  fixed: PropTypes.oneOfType([PropTypes.bool, PropTypes.oneOf(['left', 'right'])]),
-  resizable: PropTypes.bool,
-  sortable: PropTypes.bool,
-  flexGrow: PropTypes.number,
-  minWidth: PropTypes.number,
-  colSpan: PropTypes.number,
-  rowSpan: PropTypes.func,
-  treeCol: PropTypes.bool,
-  onResize: PropTypes.func,
-  children: PropTypes.node,
-  fullText: PropTypes.bool
-};
-
 Column.displayName = 'Table.Column';
 
 Column.defaultProps = {
   width: 100
 };
 
-Column.propTypes = propTypes;
-
-export const columnHandledProps = Object.keys(propTypes);
+export const columnHandledProps = [
+  'align',
+  'verticalAlign',
+  'width',
+  'fixed',
+  'resizable',
+  'sortable',
+  'flexGrow',
+  'minWidth',
+  'colSpan',
+  'rowSpan',
+  'treeCol',
+  'onResize',
+  'children',
+  'fullText'
+];
 
 export default Column;

--- a/src/ColumnGroup.tsx
+++ b/src/ColumnGroup.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { useClassNames, convertToFlex } from './utils';
 import { StandardProps } from './@types/common';
 
@@ -77,11 +76,5 @@ const ColumnGroup = React.forwardRef((props: ColumnGroupProps, ref: React.Ref<HT
 });
 
 ColumnGroup.displayName = 'Table.ColumnGroup';
-ColumnGroup.propTypes = {
-  header: PropTypes.node,
-  classPrefix: PropTypes.string,
-  groupHeaderHeight: PropTypes.number,
-  verticalAlign: PropTypes.oneOf(['top', 'middle', 'bottom'])
-};
 
 export default ColumnGroup;

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback } from 'react';
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import isNil from 'lodash/isNil';
 import Sort from '@rsuite/icons/Sort';
@@ -167,23 +166,6 @@ const HeaderCell = React.forwardRef(
 );
 
 HeaderCell.displayName = 'HeaderCell';
-HeaderCell.propTypes = {
-  index: PropTypes.number,
-  sortColumn: PropTypes.string,
-  sortType: PropTypes.oneOf(['desc', 'asc']),
-  sortable: PropTypes.bool,
-  resizable: PropTypes.bool,
-  minWidth: PropTypes.number,
-  onColumnResizeStart: PropTypes.func,
-  onColumnResizeEnd: PropTypes.func,
-  onResize: PropTypes.func,
-  onColumnResizeMove: PropTypes.func,
-  onSortColumn: PropTypes.func,
-  flexGrow: PropTypes.number,
-  fixed: PropTypes.any,
-  children: PropTypes.node,
-  renderSortIcon: PropTypes.func
-};
 
 export default HeaderCell as <Row extends RowDataType, Key extends RowKeyType>(
   props: HeaderCellProps<Row, Key> & React.RefAttributes<HTMLDivElement>

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -1,7 +1,6 @@
 import React, { useRef, useCallback, useImperativeHandle, useReducer, useMemo } from 'react';
-import * as ReactIs from 'react-is';
+import { isElement } from './utils/react-is';
 import { getTranslateDOMPositionXY } from 'dom-lib/translateDOMPositionXY';
-import PropTypes from 'prop-types';
 import isFunction from 'lodash/isFunction';
 import debounce from 'lodash/debounce';
 import Row, { RowProps } from './Row';
@@ -375,14 +374,10 @@ const Table = React.forwardRef(
     );
 
     // Check for the existence of fixed columns in all column properties.
-    const shouldFixedColumn = children.some(
-      child => ReactIs.isElement(child) && child?.props?.fixed
-    );
+    const shouldFixedColumn = children.some(child => isElement(child) && child?.props?.fixed);
 
     // Check all column properties for the existence of rowSpan.
-    const shouldRowSpanColumn = children.some(
-      child => ReactIs.isElement(child) && child?.props?.rowSpan
-    );
+    const shouldRowSpanColumn = children.some(child => isElement(child) && child?.props?.rowSpan);
 
     const visibleRows = useRef<React.ReactNode[]>([]);
     const mouseAreaRef = useRef<HTMLDivElement>(null);
@@ -1171,59 +1166,6 @@ const Table = React.forwardRef(
 );
 
 Table.displayName = 'Table';
-Table.propTypes = {
-  autoHeight: PropTypes.bool,
-  fillHeight: PropTypes.bool,
-  affixHeader: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
-  affixHorizontalScrollbar: PropTypes.oneOfType([PropTypes.bool, PropTypes.number]),
-  bordered: PropTypes.bool,
-  className: PropTypes.string,
-  classPrefix: PropTypes.string,
-  children: PropTypes.any,
-  cellBordered: PropTypes.bool,
-  data: PropTypes.array,
-  defaultExpandAllRows: PropTypes.bool,
-  defaultExpandedRowKeys: PropTypes.array,
-  defaultSortType: PropTypes.any,
-  disabledScroll: PropTypes.bool,
-  expandedRowKeys: PropTypes.array,
-  hover: PropTypes.bool,
-  height: PropTypes.number,
-  headerHeight: PropTypes.number,
-  locale: PropTypes.object,
-  loading: PropTypes.bool,
-  loadAnimation: PropTypes.bool,
-  minHeight: PropTypes.number,
-  maxHeight: PropTypes.number,
-  rowKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
-  rowHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.func]),
-  renderTreeToggle: PropTypes.func,
-  renderRowExpanded: PropTypes.func,
-  renderRow: PropTypes.func,
-  rowExpandedHeight: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
-  renderEmpty: PropTypes.func,
-  renderLoading: PropTypes.func,
-  rowClassName: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  rtl: PropTypes.bool,
-  style: PropTypes.object,
-  sortColumn: PropTypes.string,
-  sortType: PropTypes.any,
-  showHeader: PropTypes.bool,
-  shouldUpdateScroll: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
-  translate3d: PropTypes.bool,
-  wordWrap: PropTypes.any,
-  width: PropTypes.number,
-  virtualized: PropTypes.bool,
-  isTree: PropTypes.bool,
-  onRowClick: PropTypes.func,
-  onRowContextMenu: PropTypes.func,
-  onScroll: PropTypes.func,
-  onSortColumn: PropTypes.func,
-  onExpandChange: PropTypes.func,
-  onTouchStart: PropTypes.func,
-  onTouchMove: PropTypes.func,
-  onTouchEnd: PropTypes.func
-};
 
 export interface TableInstance<Row extends RowDataType, Key extends RowKeyType>
   extends React.FunctionComponent<TableProps<Row, Key>> {

--- a/src/utils/children.ts
+++ b/src/utils/children.ts
@@ -1,12 +1,12 @@
 import React from 'react';
-import * as ReactIS from 'react-is';
+import { isFragment } from './react-is';
 
 export const flattenChildren = (
   children: React.ReactNode | React.ReactNode[],
   flattened: React.ReactNode[] = []
 ) => {
   for (const child of React.Children.toArray(children)) {
-    if (ReactIS.isFragment(child)) {
+    if (isFragment(child)) {
       const childEl = child as React.ReactElement;
       if (childEl.props?.children) {
         flattenChildren(childEl.props.children, flattened);

--- a/src/utils/getTableColumns.ts
+++ b/src/utils/getTableColumns.ts
@@ -1,7 +1,7 @@
 import React from 'react';
-import * as ReactIs from 'react-is';
 import flatten from 'lodash/flatten';
 import ColumnGroup from '../ColumnGroup';
+import { isFragment } from './react-is';
 
 /**
  * Get the columns ReactElement array.
@@ -54,7 +54,7 @@ function getTableColumns(children) {
 
         return React.cloneElement(childColumn, groupCellProps);
       });
-    } else if (ReactIs.isFragment(column)) {
+    } else if (isFragment(column)) {
       // If the column is a fragment, we need to get the columns from the children.
       return getTableColumns(column.props?.children);
     } else if (Array.isArray(column)) {

--- a/src/utils/react-is.ts
+++ b/src/utils/react-is.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+
+function typeOf(object: any) {
+  if (typeof object === 'object' && object !== null) {
+    return object.type || object.$$typeof;
+  }
+}
+
+export function isFragment(children: React.ReactNode) {
+  return React.Children.count(children) === 1 && typeOf(children) === Symbol.for('react.fragment');
+}
+
+export function isElement(children: React.ReactNode) {
+  return React.isValidElement(children);
+}

--- a/test/ScrollbarSpec.js
+++ b/test/ScrollbarSpec.js
@@ -1,49 +1,48 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react';
-
-import { getDOMNode, getInstance } from './utils';
 import Scrollbar from '../src/Scrollbar';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 describe('Scrollbar', () => {
   it('Should output a scrollbar', () => {
-    const instance = getDOMNode(<Scrollbar />);
-    assert.include(instance.className, 'rs-scrollbar');
+    render(<Scrollbar />);
+
+    expect(screen.getByRole('scrollbar')).to.have.class('rs-scrollbar');
   });
 
   it('Should be vertical', () => {
-    const instance = getDOMNode(<Scrollbar vertical />);
+    render(<Scrollbar vertical />);
 
-    assert.ok(instance.className.match(/\bvertical\b/));
+    expect(screen.getByRole('scrollbar')).to.have.class('rs-scrollbar-vertical');
   });
 
   it('Should render a scroll handle', () => {
-    const scrollLength = 1000;
-    const length = 100;
-    const instance = getInstance(<Scrollbar scrollLength={scrollLength} length={length} />);
+    render(<Scrollbar scrollLength={1000} length={100} />);
 
-    assert.equal(instance.handle.style.width, `${scrollLength / length}%`);
+    expect(screen.getByRole('button').style.width).to.equal('10%');
   });
 
   it('Should call onMouseDown callback', () => {
-    const onMouseDownSpy = sinon.spy();
-    const instance = getInstance(<Scrollbar onMouseDown={onMouseDownSpy} />);
+    const onMouseDown = sinon.spy();
 
-    fireEvent.mouseDown(instance.handle);
+    render(<Scrollbar onMouseDown={onMouseDown} />);
 
-    expect(onMouseDownSpy).to.have.been.calledOnce;
+    fireEvent.mouseDown(screen.getByRole('button'));
+
+    expect(onMouseDown).to.have.been.calledOnce;
   });
 
   it('Should have a custom style', () => {
-    const fontSize = '12px';
-    const instance = getDOMNode(<Scrollbar style={{ fontSize }} />);
-    assert.equal(instance.style.fontSize, fontSize);
+    render(<Scrollbar style={{ fontSize: 12 }} />);
+
+    expect(screen.getByRole('scrollbar')).to.have.style('font-size', '12px');
   });
 
   it('Should not call `onScroll` callback', () => {
-    const instance = getInstance(<Scrollbar length={100} scrollLength={1000} onScroll={scroll} />);
-    instance.onWheelScroll(100);
-    expect(
-      instance.root.innerHTML.match(/translate3d\(\d+px,\s*(\d+)px,\s*(\d+)px\)/i)[0]
-    ).be.equal('translate3d(10px, 0px, 0px)');
+    const ref = React.createRef();
+    render(<Scrollbar length={100} scrollLength={1000} onScroll={scroll} ref={ref} />);
+
+    ref.current.onWheelScroll(100);
+
+    expect(screen.getByRole('button').style.transform).to.equal('translate3d(10px, 0px, 0px)');
   });
 });


### PR DESCRIPTION
This pull request includes several changes across various files to update dependencies, remove `prop-types`, and clean up code. The most important changes include updating dependencies in `package.json` and `pnpm-lock.yaml`, removing `prop-types` from multiple components, and replacing `react-is` with custom utility functions.

### Dependency Updates:
* Updated `@rsuite/icons` to version 1.3.0 in `package.json` and `pnpm-lock.yaml` [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L44-R51) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL18-R19).
* Updated peer dependencies for `react` and `react-dom` to version 18 in `package.json`.

### Removal of `prop-types`:
* Removed `prop-types` from `src/Cell.tsx`, `src/Column.tsx`, `src/ColumnGroup.tsx`, `src/HeaderCell.tsx`, and `src/Table.tsx` [[1]](diffhunk://#diff-6f5aa4063969484827f64cb234ad9aa341d702d6da7cd2b2414bf372d548703cL2) [[2]](diffhunk://#diff-3d44940e68ebdea5c9c63998670ecb31de47788ed54229e0da51d39164187d73L2) [[3]](diffhunk://#diff-e1ac8e0b896aa43843ad8e4e3f881b539a3490a968649ef872a27fa6e568d80dL2) [[4]](diffhunk://#diff-34efcb76cd624cfeaa9aebc1397c8e4fde9ed374fbe0b4abd7868aa28e141ad6L2) [[5]](diffhunk://#diff-5136c989c296c26b5ee1d8662fbfd58d269e40e67a6f02b35f55442ab4835c3bL2-L4).

### Code Cleanup:
* Removed `react-is` and replaced it with custom utility functions in `src/Table.tsx` and `src/utils/children.ts` [[1]](diffhunk://#diff-5136c989c296c26b5ee1d8662fbfd58d269e40e67a6f02b35f55442ab4835c3bL2-L4) [[2]](diffhunk://#diff-0ce7d076d4cc5ed0b7c90e2b615cb10a47ac56a3d468e8ab8eb493da5b5043beL2-R9).
* Cleaned up `karma.conf.js` by removing an unnecessary blank line.

These changes help modernize the codebase, reduce dependencies, and improve maintainability.