### PR TITLE
refactor: use lodash-es instead of lodash

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,7 +14,6 @@ module.exports = (api, options) => {
       '@babel/typescript'
     ],
     plugins: [
-      'lodash',
       ['@babel/plugin-transform-class-properties', { loose: true }],
       '@babel/plugin-transform-optional-chaining',
       '@babel/plugin-transform-export-namespace-from',

--- a/docs/App.tsx
+++ b/docs/App.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Nav } from 'rsuite';
 import CodeView from 'react-code-view';
-import Frame from './components/Frame';
 import TableIcon from '@rsuite/icons/Table';
 import GithubIcon from '@rsuite/icons/legacy/Github';
 import BookIcon from '@rsuite/icons/legacy/Book';
-import kebabCase from 'lodash/kebabCase';
+import Frame from './components/Frame';
+import { Nav } from 'rsuite';
+import { kebabCase } from 'lodash-es';
 
 interface ExampleType {
   title: string;

--- a/docs/index.tsx
+++ b/docs/index.tsx
@@ -1,5 +1,12 @@
 import React, { StrictMode } from 'react';
 import ReactDOM from 'react-dom/client';
+import GearIcon from '@rsuite/icons/Gear';
+import ArrowDownIcon from '@rsuite/icons/ArrowDown';
+import ArrowUpIcon from '@rsuite/icons/ArrowUp';
+import SortIcon from '@rsuite/icons/Sort';
+import fakeDataForColSpan from './data/usersForColSpan';
+import fakeDataForRowSpan from './data/usersForRowSpan';
+import App from './App';
 import {
   Popover,
   Whisper,
@@ -16,19 +23,9 @@ import {
   VStack,
   HStack
 } from 'rsuite';
-import clone from 'lodash/clone';
-import isFunction from 'lodash/isFunction';
-import get from 'lodash/get';
-import without from 'lodash/without';
-import App from './App';
+import { clone, isFunction, get, without } from 'lodash-es';
 import { Table, Column, Cell, HeaderCell, ColumnGroup } from '../src';
-import fakeDataForColSpan from './data/usersForColSpan';
-import fakeDataForRowSpan from './data/usersForRowSpan';
 import { createUser, mockUsers, mockTreeData } from './data/mock';
-import GearIcon from '@rsuite/icons/Gear';
-import ArrowDownIcon from '@rsuite/icons/ArrowDown';
-import ArrowUpIcon from '@rsuite/icons/ArrowUp';
-import SortIcon from '@rsuite/icons/Sort';
 import { useDrag, useDrop, DndProvider } from 'react-dnd';
 import { HTML5Backend } from 'react-dnd-html5-backend';
 import { faker } from '@faker-js/faker';

--- a/package.json
+++ b/package.json
@@ -42,9 +42,10 @@
     "@babel/runtime": "^7.20.1",
     "@juggle/resize-observer": "^3.4.0",
     "@rsuite/icons": "^1.3.0",
+    "@types/lodash-es": "^4.17.12",
     "classnames": "^2.3.1",
     "dom-lib": "^3.3.1",
-    "lodash": "^4.17.21"
+    "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
     "react": ">=18",
@@ -65,7 +66,6 @@
     "@commitlint/config-conventional": "^13.1.0",
     "@faker-js/faker": "^7.6.0",
     "@testing-library/react": "^13.4.0",
-    "@types/lodash": "^4.14.165",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^6.9.0",
@@ -73,7 +73,6 @@
     "autoprefixer": "^8.3.0",
     "babel-loader": "^8.2.2",
     "babel-plugin-istanbul": "^7.0.0",
-    "babel-plugin-lodash": "^3.3.4",
     "chai": "^4.3.5",
     "conventional-changelog-cli": "^2.1.1",
     "coveralls": "^3.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,13 +17,16 @@ importers:
       '@rsuite/icons':
         specifier: ^1.3.0
         version: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/lodash-es':
+        specifier: ^4.17.12
+        version: 4.17.12
       classnames:
         specifier: ^2.3.1
         version: 2.5.1
       dom-lib:
         specifier: ^3.3.1
         version: 3.3.1
-      lodash:
+      lodash-es:
         specifier: ^4.17.21
         version: 4.17.21
     devDependencies:
@@ -69,9 +72,6 @@ importers:
       '@testing-library/react':
         specifier: ^13.4.0
         version: 13.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@types/lodash':
-        specifier: ^4.14.165
-        version: 4.17.7
       '@types/react':
         specifier: ^18.2.0
         version: 18.3.4
@@ -93,9 +93,6 @@ importers:
       babel-plugin-istanbul:
         specifier: ^7.0.0
         version: 7.0.0
-      babel-plugin-lodash:
-        specifier: ^3.3.4
-        version: 3.3.4
       chai:
         specifier: ^4.3.5
         version: 4.5.0
@@ -304,10 +301,6 @@ packages:
     resolution: {integrity: sha512-i1SLeK+DzNnQ3LL/CswPCa/E5u4lh1k6IAEphON8F+cXt0t9euTshDru0q7/IqMa1PMPz5RnHuHscF8/ZJsStg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@7.25.0':
-    resolution: {integrity: sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/generator@7.26.3':
     resolution: {integrity: sha512-6FF/urZvD0sTeO7k6/B15pMLC4CHUv1426lzr3N01aHJTl046uCAh9LXW/fzeXXjPNCJ6iABW5XaWOsIZB93aQ==}
     engines: {node: '>=6.9.0'}
@@ -353,10 +346,6 @@ packages:
 
   '@babel/helper-member-expression-to-functions@7.25.9':
     resolution: {integrity: sha512-wbfdZ9w5vk0C0oyHqAJbc62+vet5prjj01jjJ8sKn3j9h3MQQlflEdXYvuqRWjHnM12coDEqiC1IRCi0U/EKwQ==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-module-imports@7.24.7':
-    resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-module-imports@7.25.9':
@@ -877,16 +866,8 @@ packages:
     resolution: {integrity: sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/template@7.25.0':
-    resolution: {integrity: sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/template@7.25.9':
     resolution: {integrity: sha512-9DGttpmPvIxBb/2uwpVo3dqJ+O6RooAFOS+lB+xDqoE2PVCE8nfoHMdZLpfCQRLwvohzXISPZcgxt80xLfsuwg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/traverse@7.25.3':
-    resolution: {integrity: sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.26.4':
@@ -1225,6 +1206,9 @@ packages:
 
   '@types/json5@0.0.29':
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+
+  '@types/lodash-es@4.17.12':
+    resolution: {integrity: sha512-0NgftHUcV4v34VhXm8QBSftKVXtbkBG3ViCjs6+eJ5a6y6Mi/jiFGPc1sC7QK+9BFhWrURE3EOggmWaSxL9OzQ==}
 
   '@types/lodash@4.17.7':
     resolution: {integrity: sha512-8wTvZawATi/lsmNu10/j2hk1KEP0IvjubqPE3cu1Xz7xfXXt5oCq3SNUz4fMIP4XGF9Ky+Ue2tBA3hcS7LSBlA==}
@@ -1779,9 +1763,6 @@ packages:
   babel-plugin-istanbul@7.0.0:
     resolution: {integrity: sha512-C5OzENSx/A+gt7t4VH1I2XsflxyPUmXRFPKBxt33xncdOmq7oROVM3bZv9Ysjjkv8OJYDMa+tKuKMvqU/H3xdw==}
     engines: {node: '>=12'}
-
-  babel-plugin-lodash@3.3.4:
-    resolution: {integrity: sha512-yDZLjK7TCkWl1gpBeBGmuaDIFhZKmkoL+Cu2MUUjv5VxUZx/z7tBGBCBcQs5RI1Bkz5LLmNdjx7paOyQtMovyg==}
 
   babel-plugin-polyfill-corejs2@0.4.11:
     resolution: {integrity: sha512-sMEJ27L0gRHShOh5G54uAAPaiCOygY/5ratXuiyb2G46FmlSpc9eFCzYVyDiPxfNbwzA7mYahmjQc5q+CZQ09Q==}
@@ -4108,11 +4089,6 @@ packages:
     resolution: {integrity: sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==}
     hasBin: true
 
-  jsesc@2.5.2:
-    resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
-    engines: {node: '>=4'}
-    hasBin: true
-
   jsesc@3.0.2:
     resolution: {integrity: sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==}
     engines: {node: '>=6'}
@@ -4327,6 +4303,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.17.21:
+    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
@@ -5547,9 +5526,6 @@ packages:
 
   require-main-filename@1.0.1:
     resolution: {integrity: sha512-IqSUtOVP4ksd1C/ej5zeEh/BIP2ajqpn8c5x+q99gvcIG/Qf0cud5raVnE/Dwd0ua9TXYDoDc0RE5hBSdz22Ug==}
-
-  require-package-name@2.0.1:
-    resolution: {integrity: sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q==}
 
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
@@ -6785,13 +6761,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.25.0':
-    dependencies:
-      '@babel/types': 7.25.2
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
-      jsesc: 2.5.2
-
   '@babel/generator@7.26.3':
     dependencies:
       '@babel/parser': 7.26.3
@@ -6866,13 +6835,6 @@ snapshots:
     dependencies:
       '@babel/traverse': 7.26.4
       '@babel/types': 7.26.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-imports@7.24.7':
-    dependencies:
-      '@babel/traverse': 7.25.3
-      '@babel/types': 7.25.2
     transitivePeerDependencies:
       - supports-color
 
@@ -7515,29 +7477,11 @@ snapshots:
     dependencies:
       regenerator-runtime: 0.14.1
 
-  '@babel/template@7.25.0':
-    dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/parser': 7.26.3
-      '@babel/types': 7.25.2
-
   '@babel/template@7.25.9':
     dependencies:
       '@babel/code-frame': 7.26.2
       '@babel/parser': 7.26.3
       '@babel/types': 7.26.3
-
-  '@babel/traverse@7.25.3':
-    dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.25.0
-      '@babel/parser': 7.25.3
-      '@babel/template': 7.25.0
-      '@babel/types': 7.25.2
-      debug: 4.3.6
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/traverse@7.26.4':
     dependencies:
@@ -7977,6 +7921,10 @@ snapshots:
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
+
+  '@types/lodash-es@4.17.12':
+    dependencies:
+      '@types/lodash': 4.17.7
 
   '@types/lodash@4.17.7': {}
 
@@ -8576,16 +8524,6 @@ snapshots:
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 6.0.3
       test-exclude: 6.0.0
-    transitivePeerDependencies:
-      - supports-color
-
-  babel-plugin-lodash@3.3.4:
-    dependencies:
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/types': 7.25.2
-      glob: 7.2.3
-      lodash: 4.17.21
-      require-package-name: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
@@ -11418,8 +11356,6 @@ snapshots:
 
   jsesc@0.5.0: {}
 
-  jsesc@2.5.2: {}
-
   jsesc@3.0.2: {}
 
   jsesc@3.1.0: {}
@@ -11688,6 +11624,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.17.21: {}
 
   lodash.debounce@4.0.8: {}
 
@@ -13039,8 +12977,6 @@ snapshots:
   require-from-string@2.0.2: {}
 
   require-main-filename@1.0.1: {}
-
-  require-package-name@2.0.1: {}
 
   requires-port@1.0.0: {}
 

--- a/src/Cell.tsx
+++ b/src/Cell.tsx
@@ -1,12 +1,10 @@
 import React, { useCallback } from 'react';
-import omit from 'lodash/omit';
-import isNil from 'lodash/isNil';
-import get from 'lodash/get';
-import { LAYER_WIDTH, ROW_HEADER_HEIGHT, ROW_HEIGHT } from './constants';
-import { useClassNames, convertToFlex } from './utils';
 import TableContext from './TableContext';
 import ArrowRight from '@rsuite/icons/ArrowRight';
 import ArrowDown from '@rsuite/icons/ArrowDown';
+import { omit, isNil, get } from 'lodash-es';
+import { LAYER_WIDTH, ROW_HEADER_HEIGHT, ROW_HEIGHT } from './constants';
+import { useClassNames, convertToFlex } from './utils';
 import { StandardProps, RowDataType, RowKeyType } from './@types/common';
 import { columnHandledProps } from './Column';
 

--- a/src/ColumnResizeHandler.tsx
+++ b/src/ColumnResizeHandler.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useContext, useEffect, useRef } from 'react';
-import clamp from 'lodash/clamp';
 import DOMMouseMoveTracker from 'dom-lib/DOMMouseMoveTracker';
-import { useClassNames } from './utils';
 import TableContext from './TableContext';
+import { clamp } from 'lodash-es';
+import { useClassNames } from './utils';
 import { RESIZE_MIN_WIDTH } from './constants';
 import type { StandardProps } from './@types/common';
 

--- a/src/HeaderCell.tsx
+++ b/src/HeaderCell.tsx
@@ -1,12 +1,12 @@
 import React, { useState, useCallback } from 'react';
 import classNames from 'classnames';
-import isNil from 'lodash/isNil';
 import Sort from '@rsuite/icons/Sort';
 import SortUp from '@rsuite/icons/SortUp';
 import SortDown from '@rsuite/icons/SortDown';
 import ColumnResizeHandler, { FixedType } from './ColumnResizeHandler';
-import { useUpdateEffect, useClassNames } from './utils';
 import Cell, { InnerCellProps } from './Cell';
+import { useUpdateEffect, useClassNames } from './utils';
+import { isNil } from 'lodash-es';
 import { RowDataType, RowKeyType } from './@types/common';
 
 export interface HeaderCellProps<Row extends RowDataType, Key extends RowKeyType>

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -1,8 +1,4 @@
 import React, { useRef, useCallback, useImperativeHandle, useReducer, useMemo } from 'react';
-import { isElement } from './utils/react-is';
-import { getTranslateDOMPositionXY } from 'dom-lib/translateDOMPositionXY';
-import isFunction from 'lodash/isFunction';
-import debounce from 'lodash/debounce';
 import Row, { RowProps } from './Row';
 import CellGroup from './CellGroup';
 import Scrollbar, { ScrollbarInstance } from './Scrollbar';
@@ -14,6 +10,9 @@ import Cell, { InnerCellProps } from './Cell';
 import HeaderCell, { HeaderCellProps } from './HeaderCell';
 import Column, { ColumnProps } from './Column';
 import ColumnGroup from './ColumnGroup';
+import { debounce, isFunction } from 'lodash-es';
+import { isElement } from './utils/react-is';
+import { getTranslateDOMPositionXY } from 'dom-lib/translateDOMPositionXY';
 import {
   SCROLLBAR_WIDTH,
   CELL_PADDING_HEIGHT,

--- a/src/utils/defer.ts
+++ b/src/utils/defer.ts
@@ -1,4 +1,4 @@
-import defer from 'lodash/defer';
+import { defer } from 'lodash-es';
 
 /**
  * Defer callbacks to wait for DOM rendering to complete.

--- a/src/utils/getTableColumns.ts
+++ b/src/utils/getTableColumns.ts
@@ -1,6 +1,6 @@
 import React from 'react';
-import flatten from 'lodash/flatten';
 import ColumnGroup from '../ColumnGroup';
+import { flatten } from 'lodash-es';
 import { isFragment } from './react-is';
 
 /**

--- a/src/utils/getTotalByColumns.ts
+++ b/src/utils/getTotalByColumns.ts
@@ -1,6 +1,6 @@
 import React from 'react';
-import isPlainObject from 'lodash/isPlainObject';
 import getColumnProps from './getColumnProps';
+import { isPlainObject } from 'lodash-es';
 import { RowDataType } from '../@types/common';
 import { ColumnProps } from '../Column';
 

--- a/src/utils/mergeCells.tsx
+++ b/src/utils/mergeCells.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import isFunction from 'lodash/isFunction';
-import get from 'lodash/get';
-import isNil from 'lodash/isNil';
+import { get, isNil, isFunction } from 'lodash-es';
 import ColumnGroup from '../ColumnGroup';
 import HeaderCell from '../HeaderCell';
 

--- a/src/utils/prefix.ts
+++ b/src/utils/prefix.ts
@@ -1,5 +1,5 @@
 import classNames from 'classnames';
-import curry from 'lodash/curry';
+import { curry } from 'lodash-es';
 
 export function prefix(pre: string, className: string | string[]): string {
   if (!pre || !className) {
@@ -18,4 +18,6 @@ export function prefix(pre: string, className: string | string[]): string {
   return `${pre}-${className}`;
 }
 
-export default curry(prefix);
+const curryPrefix: (pre: string, className: string | string[]) => string = curry(prefix);
+
+export default curryPrefix;

--- a/src/utils/useCellDescriptor.ts
+++ b/src/utils/useCellDescriptor.ts
@@ -2,18 +2,17 @@ import React, { useState, useCallback, useRef } from 'react';
 import addStyle from 'dom-lib/addStyle';
 import addClass from 'dom-lib/addClass';
 import removeClass from 'dom-lib/removeClass';
-import omit from 'lodash/omit';
-import merge from 'lodash/merge';
-import { SCROLLBAR_WIDTH, SORT_TYPE } from '../constants';
-import { SortType, RowDataType } from '../@types/common';
 import useControlled from './useControlled';
 import getTableColumns from './getTableColumns';
 import getTotalByColumns from './getTotalByColumns';
 import getColumnProps from './getColumnProps';
 import useUpdateEffect from './useUpdateEffect';
-import { ColumnProps } from '../Column';
 import flushSync from './flushSync';
 import useMount from './useMount';
+import { ColumnProps } from '../Column';
+import { omit, merge } from 'lodash-es';
+import { SCROLLBAR_WIDTH, SORT_TYPE } from '../constants';
+import { SortType, RowDataType } from '../@types/common';
 
 interface CellDescriptorProps<Row> {
   children: React.ReactNode[];

--- a/src/utils/useTableDimension.ts
+++ b/src/utils/useTableDimension.ts
@@ -2,14 +2,14 @@ import React, { useRef, useCallback, useMemo } from 'react';
 import getWidth from 'dom-lib/getWidth';
 import getHeight from 'dom-lib/getHeight';
 import getOffset from 'dom-lib/getOffset';
-import { SCROLLBAR_WIDTH } from '../constants';
-import { ResizeObserver } from '@juggle/resize-observer';
 import useMount from './useMount';
 import useUpdateLayoutEffect from './useUpdateLayoutEffect';
 import useIntersectionObserver from './useIntersectionObserver';
 import isNumberOrTrue from './isNumberOrTrue';
+import { ResizeObserver } from '@juggle/resize-observer';
+import { debounce } from 'lodash-es';
+import { SCROLLBAR_WIDTH } from '../constants';
 import { RowDataType, ElementOffset } from '../@types/common';
-import debounce from 'lodash/debounce';
 
 interface TableDimensionProps<Row, Key> {
   data?: readonly Row[];

--- a/src/utils/useTableRows.ts
+++ b/src/utils/useTableRows.ts
@@ -1,9 +1,9 @@
 import { useState, useCallback, useRef } from 'react';
+import { isEmpty } from 'lodash-es';
+import { RowDataType } from '../@types/common';
 import getHeight from 'dom-lib/getHeight';
 import useUpdateLayoutEffect from './useUpdateLayoutEffect';
 import useMount from './useMount';
-import isEmpty from 'lodash/isEmpty';
-import { RowDataType } from '../@types/common';
 import defer from './defer';
 
 interface TableRowsProps<Row, Key> {


### PR DESCRIPTION
This pull request involves a significant refactor to replace `lodash` with `lodash-es` throughout the codebase. The changes include updating imports, modifying the `package.json` dependencies, and adjusting the `pnpm-lock.yaml` file accordingly. Here are the most important changes:

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R45-R48): Replaced `lodash` with `lodash-es` and added `@types/lodash-es`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R45-R48) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L68-L76)
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR20-R29): Updated dependencies to replace `lodash` with `lodash-es` and removed related `lodash` packages. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR20-R29) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL72-L74) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL96-L98) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL307-L310) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL358-L361) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL880-L891) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR11628-R11629) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR4307-R4309) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8582-L8591) [[10]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL11421-L11422) [[11]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL13043-L13044) [[12]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6788-L6794) [[13]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL6872-L6878) [[14]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7518-L7541) [[15]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7925-R7928)

### Codebase Refactor:
* [`docs/App.tsx`](diffhunk://#diff-1551e72a447482bc5ec183c16a47f8a2ed79ae402088c87bf004998022575a52L2-R8): Reordered imports and replaced `lodash` imports with `lodash-es`.
* [`docs/index.tsx`](diffhunk://#diff-13356dfd812b160867cc6046fb5182bedb7b94bcd3f8effd7bed71fd37a3a870R3-R9): Updated imports to use `lodash-es` and reordered them. [[1]](diffhunk://#diff-13356dfd812b160867cc6046fb5182bedb7b94bcd3f8effd7bed71fd37a3a870R3-R9) [[2]](diffhunk://#diff-13356dfd812b160867cc6046fb5182bedb7b94bcd3f8effd7bed71fd37a3a870L19-L31)
* [`src/Cell.tsx`](diffhunk://#diff-6f5aa4063969484827f64cb234ad9aa341d702d6da7cd2b2414bf372d548703cL2-R7): Replaced `lodash` imports with `lodash-es`.
* [`src/ColumnResizeHandler.tsx`](diffhunk://#diff-71d103b8b72cd6a5dae5b5c2ef2e39230d27c3678b8d6d15a63d124435d09849L2-R5): Replaced `lodash` imports with `lodash-es`.
* [`src/HeaderCell.tsx`](diffhunk://#diff-34efcb76cd624cfeaa9aebc1397c8e4fde9ed374fbe0b4abd7868aa28e141ad6L3-R9): Replaced `lodash` imports with `lodash-es`.
* [`src/Table.tsx`](diffhunk://#diff-5136c989c296c26b5ee1d8662fbfd58d269e40e67a6f02b35f55442ab4835c3bL2-L5): Replaced `lodash` imports with `lodash-es` and reordered them. [[1]](diffhunk://#diff-5136c989c296c26b5ee1d8662fbfd58d269e40e67a6f02b35f55442ab4835c3bL2-L5) [[2]](diffhunk://#diff-5136c989c296c26b5ee1d8662fbfd58d269e40e67a6f02b35f55442ab4835c3bR13-R15)
* [`src/utils/defer.ts`](diffhunk://#diff-59e808eaae4062cc8c6b278cc2296e9d79c80bed08a29a3e6e584dad74928cf9L1-R1): Replaced `lodash` import with `lodash-es`.
* [`src/utils/getTableColumns.ts`](diffhunk://#diff-8a4626f17f830bfc2ff8fd4406ea46cb804f18662d3ca31b9c7f717ebadf8a88L2-R3): Replaced `lodash` import with `lodash-es`.

### Babel Configuration:
* [`babel.config.js`](diffhunk://#diff-09c56b2bf95de2a608a36afef3b6893146a959d6739be0a154dc9c9f02d80f24L17): Removed the `lodash` plugin.