### PR TITLE
refactor: update table utils and dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "@juggle/resize-observer": "^3.3.1",
     "classnames": "^2.3.1",
     "dom-lib": "^3.3.1",
-    "lodash": "^4.17.21",
-    "react-is": "^17.0.2"
+    "lodash": "^4.17.21"
   },
   "peerDependencies": {
     "react": ">=16.8.0",
@@ -79,7 +78,6 @@
     "@types/lodash": "^4.14.165",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
-    "@types/react-is": "^18.2.4",
     "autoprefixer": "^8.3.0",
     "babel-loader": "^8.2.2",
     "babel-plugin-date-fns": "^0.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,9 +23,6 @@ importers:
       lodash:
         specifier: ^4.17.21
         version: 4.17.21
-      react-is:
-        specifier: ^17.0.2
-        version: 17.0.2
     devDependencies:
       '@babel/cli':
         specifier: ^7.25.9
@@ -105,9 +102,6 @@ importers:
       '@types/react-dom':
         specifier: ^18.2.0
         version: 18.3.5(@types/react@18.3.18)
-      '@types/react-is':
-        specifier: ^18.2.4
-        version: 18.3.1
       autoprefixer:
         specifier: ^8.3.0
         version: 8.6.5
@@ -1224,9 +1218,6 @@ packages:
     resolution: {integrity: sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==}
     peerDependencies:
       '@types/react': ^18.0.0
-
-  '@types/react-is@18.3.1':
-    resolution: {integrity: sha512-zts4lhQn5ia0cF/y2+3V6Riu0MAfez9/LJYavdM8TvcVl+S91A/7VWxyBT8hbRuWspmuCaiGI0F41OJYGrKhRA==}
 
   '@types/react-window@1.8.8':
     resolution: {integrity: sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==}
@@ -8255,10 +8246,6 @@ snapshots:
   '@types/q@1.5.8': {}
 
   '@types/react-dom@18.3.5(@types/react@18.3.18)':
-    dependencies:
-      '@types/react': 18.3.18
-
-  '@types/react-is@18.3.1':
     dependencies:
       '@types/react': 18.3.18
 

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -1,6 +1,4 @@
 import React, { useRef, useCallback, useImperativeHandle, useReducer, useMemo } from 'react';
-import * as ReactIs from 'react-is';
-import { getTranslateDOMPositionXY } from 'dom-lib/translateDOMPositionXY';
 import isFunction from 'lodash/isFunction';
 import debounce from 'lodash/debounce';
 import Row, { RowProps } from './Row';
@@ -14,6 +12,8 @@ import Cell, { InnerCellProps } from './Cell';
 import HeaderCell, { HeaderCellProps } from './HeaderCell';
 import Column, { ColumnProps } from './Column';
 import ColumnGroup from './ColumnGroup';
+import { isElement } from './utils/react-is';
+import { getTranslateDOMPositionXY } from 'dom-lib/translateDOMPositionXY';
 import {
   SCROLLBAR_WIDTH,
   CELL_PADDING_HEIGHT,
@@ -374,14 +374,10 @@ const Table = React.forwardRef(
     );
 
     // Check for the existence of fixed columns in all column properties.
-    const shouldFixedColumn = children.some(
-      child => ReactIs.isElement(child) && child?.props?.fixed
-    );
+    const shouldFixedColumn = children.some(child => isElement(child) && child?.props?.fixed);
 
     // Check all column properties for the existence of rowSpan.
-    const shouldRowSpanColumn = children.some(
-      child => ReactIs.isElement(child) && child?.props?.rowSpan
-    );
+    const shouldRowSpanColumn = children.some(child => isElement(child) && child?.props?.rowSpan);
 
     const visibleRows = useRef<React.ReactNode[]>([]);
     const mouseAreaRef = useRef<HTMLDivElement>(null);

--- a/src/utils/children.ts
+++ b/src/utils/children.ts
@@ -1,12 +1,12 @@
 import React from 'react';
-import * as ReactIS from 'react-is';
+import { isFragment } from './react-is';
 
 export const flattenChildren = (
   children: React.ReactNode | React.ReactNode[],
   flattened: React.ReactNode[] = []
 ) => {
   for (const child of React.Children.toArray(children)) {
-    if (ReactIS.isFragment(child)) {
+    if (isFragment(child)) {
       const childEl = child as React.ReactElement;
       if (childEl.props?.children) {
         flattenChildren(childEl.props.children, flattened);

--- a/src/utils/getTableColumns.ts
+++ b/src/utils/getTableColumns.ts
@@ -1,7 +1,7 @@
 import React from 'react';
-import * as ReactIs from 'react-is';
 import flatten from 'lodash/flatten';
 import ColumnGroup from '../ColumnGroup';
+import { isFragment } from './react-is';
 
 /**
  * Get the columns ReactElement array.
@@ -55,7 +55,7 @@ function getTableColumns(children) {
 
         return React.cloneElement(childColumn, groupCellProps);
       });
-    } else if (ReactIs.isFragment(column)) {
+    } else if (isFragment(column)) {
       // If the column is a fragment, we need to get the columns from the children.
       return getTableColumns(column.props && column.props.children);
     } else if (Array.isArray(column)) {

--- a/src/utils/react-is.ts
+++ b/src/utils/react-is.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+
+function typeOf(object: any) {
+  if (typeof object === 'object' && object !== null) {
+    return object.type || object.$$typeof;
+  }
+}
+
+export function isFragment(children: React.ReactNode) {
+  return React.Children.count(children) === 1 && typeOf(children) === Symbol.for('react.fragment');
+}
+
+export function isElement(children: React.ReactNode) {
+  return React.isValidElement(children);
+}


### PR DESCRIPTION
This pull request focuses on removing the dependency on `react-is` and replacing its functionality with custom utility functions. Additionally, it updates the project dependencies accordingly. The most important changes include modifications to the `package.json`, `pnpm-lock.yaml`, and several source files to implement the new utility functions.

Dependency updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L48-R48): Removed `react-is` from dependencies and `@types/react-is` from devDependencies. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L48-R48) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L82)
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL26-L28): Removed `react-is` and `@types/react-is` entries from the lock file. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL26-L28) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL108-L110) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL1228-L1230) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8261-L8264)

Code changes:

* [`src/Table.tsx`](diffhunk://#diff-5136c989c296c26b5ee1d8662fbfd58d269e40e67a6f02b35f55442ab4835c3bL2-L3): Replaced `react-is` imports with custom utility functions `isElement` and `getTranslateDOMPositionXY`. [[1]](diffhunk://#diff-5136c989c296c26b5ee1d8662fbfd58d269e40e67a6f02b35f55442ab4835c3bL2-L3) [[2]](diffhunk://#diff-5136c989c296c26b5ee1d8662fbfd58d269e40e67a6f02b35f55442ab4835c3bR15-R16) [[3]](diffhunk://#diff-5136c989c296c26b5ee1d8662fbfd58d269e40e67a6f02b35f55442ab4835c3bL377-R380)
* [`src/utils/children.ts`](diffhunk://#diff-0ce7d076d4cc5ed0b7c90e2b615cb10a47ac56a3d468e8ab8eb493da5b5043beL2-R9): Replaced `react-is` import with custom `isFragment` utility function.
* [`src/utils/getTableColumns.ts`](diffhunk://#diff-8a4626f17f830bfc2ff8fd4406ea46cb804f18662d3ca31b9c7f717ebadf8a88L2-R4): Replaced `react-is` import with custom `isFragment` utility function. [[1]](diffhunk://#diff-8a4626f17f830bfc2ff8fd4406ea46cb804f18662d3ca31b9c7f717ebadf8a88L2-R4) [[2]](diffhunk://#diff-8a4626f17f830bfc2ff8fd4406ea46cb804f18662d3ca31b9c7f717ebadf8a88L58-R58)
* [`src/utils/react-is.ts`](diffhunk://#diff-6b3f161de275f894a6191c28eff7914588cace3f3f18905d3f86b3af53c7aa81R1-R15): Added new utility functions `isFragment` and `isElement` to replace `react-is` functionality.