### PR TITLE
feat: add enabledRowHighlight to highlight the selected row

### DIFF
--- a/docs/examples/EnabledRowHighlightTable.md
+++ b/docs/examples/EnabledRowHighlightTable.md
@@ -1,0 +1,96 @@
+### Enabled Row EnabledRowHighlight
+
+<!--start-code-->
+
+```js
+const fakeData = mockUsers(20);
+
+const App = () => {
+  // data is empty initially
+  const [data, setData] = React.useState([]);
+
+  React.useEffect(() => {
+    // We load data after first render
+    setData(fakeData);
+  }, []);
+
+  const handleScroll = (x, y) => {
+    // This should print 200 under normal conditions
+    console.log(data.length);
+  };
+
+  return (
+    <Table
+      height={400}
+      data={data}
+      onScroll={handleScroll}
+      cellBordered
+      bordered
+      onRowClick={data => {
+        console.log(data);
+      }}
+      enabledRowHighlight
+    >
+      <Column width={70} align="center" fixed>
+        <HeaderCell>Id</HeaderCell>
+        <Cell dataKey="id" />
+      </Column>
+
+      <Column width={130} fixed>
+        <HeaderCell>First Name</HeaderCell>
+        <Cell dataKey="firstName" />
+      </Column>
+
+      <Column width={130}>
+        <HeaderCell>Last Name</HeaderCell>
+        <Cell dataKey="lastName" />
+      </Column>
+
+      <Column width={200}>
+        <HeaderCell>City</HeaderCell>
+        <Cell dataKey="city" />
+      </Column>
+
+      <Column width={200}>
+        <HeaderCell>Street</HeaderCell>
+        <Cell dataKey="street" />
+      </Column>
+
+      <Column width={200}>
+        <HeaderCell>Company</HeaderCell>
+        <Cell dataKey="company" />
+      </Column>
+
+      <Column width={200}>
+        <HeaderCell>Email</HeaderCell>
+        <Cell dataKey="email" />
+      </Column>
+
+      <Column width={200}>
+        <HeaderCell>Email</HeaderCell>
+        <Cell dataKey="email" />
+      </Column>
+
+      <Column width={200} fixed="right">
+        <HeaderCell>Action</HeaderCell>
+
+        <Cell>
+          {rowData => {
+            function handleAction() {
+              alert(`id:${rowData.id}`);
+            }
+            return (
+              <span>
+                <a onClick={handleAction}> Edit </a> | <a onClick={handleAction}> Remove </a>
+              </span>
+            );
+          }}
+        </Cell>
+      </Column>
+    </Table>
+  );
+};
+ReactDOM.render(<App />);
+```
+
+<!--end-code-->

--- a/docs/index.tsx
+++ b/docs/index.tsx
@@ -157,6 +157,10 @@ const examples = [
     content: require('./examples/EditTable.md')
   },
   {
+    title: 'Enabled Row Highlight',
+    content: require('./examples/EnabledRowHighlightTable.md')
+  },
+  {
     title: 'Loading',
     content: require('./examples/LoadingTable.md')
   },

--- a/src/less/table.less
+++ b/src/less/table.less
@@ -18,6 +18,14 @@
     transition: none;
   }
 
+  &-enabled-row-highlight {
+    cursor: pointer;
+  }
+
+  &-row-highlighted &-cell {
+    background-color: @row-higlight-color !important;
+  }
+
   &-hover &-body-row-wrapper &-row:hover {
     background: @row-hover-color;
   }

--- a/src/less/variables.less
+++ b/src/less/variables.less
@@ -10,6 +10,7 @@
 @pagination-background: #f5f5f5;
 @resize-mouse-color: @H500;
 @row-hover-color: #f2faff;
+@row-higlight-color: #d6eefe;
 
 // Loader
 


### PR DESCRIPTION
Hello everyone,

Recently, while working on a project that involved the Table component alongside another component to visualize selected row data, I noticed the need for an easier way to highlight the selected row.

As a learning exercise, I implemented a new boolean property named enabledRowHighlight, which natively enables row highlighting. When this property is set on the Table component, it will automatically apply a background color to the selected row, improving visibility without additional manual handling.

Feedback and suggestions are very welcome. Let me know what you think!